### PR TITLE
changes to getSecret() method

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,7 +1,7 @@
 [
     {
-        "cve": "SNYK-JS-TAFFYDB-2992450",
-        "alwaysOmit": true,
-        "comment": "Internal dependency of a dev dependency."
+        "cve": "SNYK-JS-WORDWRAP-3149973",
+        "comment": "Dev dependency.",
+        "expiration": "2023-07-01T00:00:00+05:30"
     }
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 repos:
   - repo: git@github.ibm.com:Whitewater/whitewater-detect-secrets
     # If you desire to use a specific version of whitewater-detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
-    rev: 0.13.1+ibm.58.dss
+    rev: 0.13.1+ibm.61.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-13T04:39:14Z",
+  "generated_at": "2023-06-16T06:35:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -61,7 +61,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.58.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/lib/AppConfiguration.js
+++ b/lib/AppConfiguration.js
@@ -275,13 +275,13 @@ const AppConfiguration = () => {
      *
      * @method module:AppConfiguration#getSecret
      * @param {string} propertyId - Id of the secret property from App Configuration.
-     * @param {object} secretManagerObj - Secret Manager client object obtained from secret manager sdk.
+     * @param {object} secretsManagerService - Secret Manager client object obtained by initializing the secret manager sdk.
      * @returns {object|null} SecretProperty object.
      */
-    function getSecret(propertyId, secretManagerObj) {
+    function getSecret(propertyId, secretsManagerService) {
       if (isInitialized && isInitializedConfig) {
-        if (secretManagerObj !== undefined && secretManagerObj !== null) {
-          return configurationHandlerInstance.getSecret(propertyId, secretManagerObj);
+        if (secretsManagerService !== undefined && secretsManagerService !== null) {
+          return configurationHandlerInstance.getSecret(propertyId, secretsManagerService);
         }
         logger.error(Constants.INVALID_SECRET_MANAGER_CLIENT_MESSAGE);
         return null;

--- a/lib/configurations/ConfigurationHandler.js
+++ b/lib/configurations/ConfigurationHandler.js
@@ -425,14 +425,14 @@ const ConfigurationHandler = () => {
      *
      * @method module:ConfigurationHandler#getSecret
      * @param {string} propertyId - The property Id
-     * @param {string} secretManagerObj - The secret manager client object
+     * @param {string} secretsManagerService - The secret manager client object
      * @returns {object|null} SecretProperty object.
      */
-    function getSecret(propertyId, secretManagerObj) {
+    function getSecret(propertyId, secretsManagerService) {
       const propertyObj = getProperty(propertyId);
       if (propertyObj !== null) {
         if (propertyObj.getPropertyDataType() === Constants.SECRETREF) {
-          _secretMap[propertyId] = secretManagerObj;
+          _secretMap[propertyId] = secretsManagerService;
           return new SecretProperty(propertyId);
         }
         logger.error(`Invalid operation: getSecret() cannot be called on a ${propertyObj.getPropertyDataType()} property.`);

--- a/lib/configurations/internal/Constants.js
+++ b/lib/configurations/internal/Constants.js
@@ -52,7 +52,7 @@ const Constants = {
   DEFAULT_ROLLOUT_PERCENTAGE: '$default',
   DEFAULT_FEATURE_VALUE: '$default',
   DEFAULT_PROPERTY_VALUE: '$default',
-  INVALID_SECRET_MANAGER_CLIENT_MESSAGE: 'Secret Manager object passed to getSecret method is invalid.',
+  INVALID_SECRET_MANAGER_CLIENT_MESSAGE: 'Secret Manager object passed to getSecret method is null or undefined.',
   SECRETREF : 'SECRETREF',
   SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS: 'Successfully fetched the configurations',
   ERROR_POSTING_METERING_DATA: 'Error while posting metering data',

--- a/lib/configurations/models/SecretProperty.js
+++ b/lib/configurations/models/SecretProperty.js
@@ -34,7 +34,7 @@ class SecretProperty {
    * @param {*} entityAttributes - A JSON object consisting of the attribute name and their values that defines the specified entity.
    * 
    * @return {Promise|null} returns a Promise that either resolves with the response from the secret manager or rejects with an Error.
-   * The resolved value is the actual secret value of the evaluated secret reference. The response contains the body, the headers, the status code, and the status text.
+   * The resolved value will be the actual secret value of the evaluated secret reference. The response contains the body, the headers, the status code, and the status text.
    * If using async/await, use try/catch for handling errors.
    */
   getCurrentValue(entityId, entityAttributes) {
@@ -47,28 +47,18 @@ class SecretProperty {
     const { configurationHandler } = require('../ConfigurationHandler');
     const configurationHandlerInstance = configurationHandler.currentInstance();
     const propertyObj = configurationHandlerInstance.getProperty(this.propertyId);
-    if (propertyObj.value !== undefined && Object.prototype.hasOwnProperty.call(propertyObj.value, 'secret_type')) {
-      const secretType = propertyObj.value.secret_type;
-      const propertyCurrentVal = propertyObj.getCurrentValue(entityId, entityAttributes);
-      if (propertyCurrentVal !== null) {
-        if (propertyCurrentVal.value !== undefined && Object.prototype.hasOwnProperty.call(propertyCurrentVal.value, 'id')) {
-          const { id } = propertyCurrentVal.value;
-          const secretMap = configurationHandlerInstance.getSecretsMap();
-          const secretManagerObj = secretMap[this.propertyId];
-          // Here we are not awaiting for the promise to resolve or not even catching the rejection. Instead, we are directly propogating the
-          // returned promise from sm sdk to the output of getCurrentValue.
-          return secretManagerObj.getSecret({
-            secretType,
-            id,
-          })
-        }
-        logger.error(`SecretProperty Evaluation: Secret Id is missing from the Property : ${propertyObj.getPropertyName()}`);
-        return null;
-      }
-      logger.error(`SecretProperty Evaluation: Property evaluated value is invalid.`);
-      return null;
+    const propertyCurrentVal = propertyObj.getCurrentValue(entityId, entityAttributes);
+    if (propertyCurrentVal.value !== undefined && Object.prototype.hasOwnProperty.call(propertyCurrentVal.value, 'id')) {
+      const { id } = propertyCurrentVal.value;
+      const secretMap = configurationHandlerInstance.getSecretsMap();
+      const secretManagerObj = secretMap[this.propertyId];
+      // Here we are not awaiting for the promise to resolve or not even catching the rejection. Instead, we are directly passing the
+      // returned promise from getSecret(). The caller of this method has to explicitly resolve the promise and handle the errors
+      return secretManagerObj.getSecret({
+        id,
+      })
     }
-    logger.error(`SecretProperty Evaluation: secret_type is missing from the Property value of : ${propertyObj.getPropertyName()}`);
+    logger.error(`SecretProperty Evaluation: Secret Id is missing from the Property : ${propertyObj.getPropertyName()}`);
     return null;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ibm-appconfiguration-node-sdk",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "IBM Cloud App Configuration Node.js SDK",
   "main": "./lib/AppConfiguration.js",
   "scripts": {


### PR DESCRIPTION
- IBM cloud secrets manager has migrated their APIs to v2. This has impact on the [getSecret()](https://github.com/IBM/appconfiguration-node-sdk/blob/601fcb5b6d61e72e77371d5ff71b0fb491df5c5c/lib/AppConfiguration.js#L281) method of this SDK. Necessary changes have been made to all the internal references of getSecret() to work with secrets manager v2 initialised client.
- readme updates
- release version updated to v0.5.0 (minor release)