### PR TITLE
improved websocket error handling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-07-28T08:42:08Z",
+  "generated_at": "2023-08-07T13:30:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/lib/configurations/ConfigurationHandler.js
+++ b/lib/configurations/ConfigurationHandler.js
@@ -25,7 +25,7 @@ const fs = require('fs');
 const { UrlBuilder } = require('../core/UrlBuilder');
 const { Logger } = require('../core/Logger');
 const { Metering } = require('../core/Metering');
-const { getBaseServiceClient, getHeaders, getToken, setAuthenticator } = require('../core/ApiManager');
+const { getBaseServiceClient, getHeaders, setAuthenticator } = require('../core/ApiManager');
 const { Feature } = require('./models/Feature');
 const { Property } = require('./models/Property');
 const { Segment } = require('./models/Segment');
@@ -33,7 +33,7 @@ const { SegmentRules } = require('./models/SegmentRules');
 const { SecretProperty } = require("./models/SecretProperty");
 const { FileManager } = require('./internal/FileManager');
 const { getNormalizedValue } = require('./internal/Utils');
-const { socketClient, closeWebSocket } = require('./internal/Socket');
+const { connectWebSocket} = require('./internal/Socket');
 const { events } = require('./internal/Events');
 const { Constants } = require('./internal/Constants');
 const { checkInternet } = require('./internal/Connectivity');
@@ -234,29 +234,6 @@ const ConfigurationHandler = () => {
       }
     }
 
-    /**
-     * Perform websocket connect to appconfiguration server
-     *
-     * @async
-     * @method module:ConfigurationHandler#connectWebSocket
-     */
-    async function connectWebSocket() {
-      try {
-        const urlForWebsocket = urlBuilder.getWebSocketUrl(_collectionId, _environmentId);
-        const _bearerToken = await getToken();
-        const headers = {
-          Authorization: _bearerToken,
-        };
-        closeWebSocket(); // close existing websocket connection if any
-        socketClient.connect(
-          urlForWebsocket, [], [], headers,
-        );
-      } catch (error) {
-        logger.warning(error.message);
-        logger.warning('Connection to the App Configuration server failed with unexpected error');
-      }
-    }
-
     function isJSONDataEmpty(jsonData) {
       if (Object.keys(jsonData).length === 0) {
         return true;
@@ -304,6 +281,7 @@ const ConfigurationHandler = () => {
       _persistentCacheDirectory = options.persistentCacheDirectory;
       _bootstrapFile = options.bootstrapFile;
       _liveUpdate = options.liveConfigUpdateEnabled;
+      urlBuilder.setWebSocketUrl(_collectionId, _environmentId);
 
       if (_persistentCacheDirectory) {
         persistentData = FileManager.getFileData(path.join(_persistentCacheDirectory, 'appconfiguration.json'));
@@ -679,23 +657,17 @@ const ConfigurationHandler = () => {
     });
 
     // Socket Listeners
-    emitter.on(Constants.SOCKET_CONNECTION_ERROR, (error) => {
-      logger.warning(`Connecting to app configuration server failed. ${error}`);
-      logger.warning(Constants.CREATE_NEW_CONNECTION);
+    emitter.on(Constants.SOCKET_CONNECTION_ERROR, () => {
       _onSocketRetry = true;
       connectWebSocket();
     });
 
-    emitter.on(Constants.SOCKET_LOST_ERROR, (error) => {
-      logger.warning(`Connecting to app configuration server lost. ${error}`);
-      logger.warning(Constants.CREATE_NEW_CONNECTION);
+    emitter.on(Constants.SOCKET_LOST_ERROR, () => {
       _onSocketRetry = true;
       connectWebSocket();
     });
 
     emitter.on(Constants.SOCKET_CONNECTION_CLOSE, () => {
-      logger.warning('server connection closed. Creating a new connection to the server.');
-      logger.warning(Constants.CREATE_NEW_CONNECTION);
       _onSocketRetry = true;
       connectWebSocket();
     });

--- a/lib/configurations/internal/Socket.js
+++ b/lib/configurations/internal/Socket.js
@@ -21,52 +21,63 @@
  */
 
 const WebSocketClient = require('websocket').client;
+const { events } = require('./Events');
+const { Constants } = require('./Constants');
+const { UrlBuilder } = require('../../core/UrlBuilder');
+const { Logger } = require('../../core/Logger');
+const { getToken } = require('../../core/ApiManager');
+const pkg = require('../../../package.json');
 
-const client = new WebSocketClient({
-  closeTimeout: 120000,
-});
-const {
-  events,
-} = require('./Events');
-const {
-  Constants,
-} = require('./Constants');
-
+const socketClient = new WebSocketClient({ closeTimeout: 120000 });
+const logger = Logger.getInstance();
+const urlBuilder = UrlBuilder.getInstance();
 const emitter = events.getInstance();
+let socketConnectComplete = true;
 let connectionObj;
-
-/**
- * Checks the connection status.
- * If connection exists, it closes the connection.
- *
- * @method module:WebSocketClient#closeWebSocket
- */
-function closeWebSocket() {
-  if (connectionObj && connectionObj.connected) {
-    connectionObj.close(Constants.CUSTOM_SOCKET_CLOSE_REASON_CODE);
-  }
-}
 
 /**
  * Listeners for websocket connection.
  */
-client.on('connectFailed', (error) => {
-  emitter.emit(Constants.SOCKET_CONNECTION_ERROR, `Error while connecting to server ${error.message}`);
+socketClient.on('httpResponse', async (response) => {
+  socketConnectComplete = true;
+  const { statusCode } = response;
+  const errMsg =
+    `WebSocket connect request to the App Configuration server failed. Status code: ${statusCode}. Message: ${response.statusMessage}`
+  if (statusCode >= 400 && statusCode <= 499 && statusCode !== 429) {
+    // 'Do Nothing! Since websocket connect failed due to client-side error.
+    logger.error(errMsg);
+    return;
+  }
+  logger.warning(`${errMsg} Retrying websocket connect in 15 seconds...`);
+  await new Promise(resolve => setTimeout(resolve, 15000));
+  emitter.emit(Constants.SOCKET_CONNECTION_ERROR, response);
+})
+
+socketClient.on('connectFailed', async (error) => {
+  socketConnectComplete = true;
+  logger.warning(`connectFailed: ${error.message} Retrying websocket connect in 15 seconds...`);
+  await new Promise(resolve => setTimeout(resolve, 15000));
+  emitter.emit(Constants.SOCKET_CONNECTION_ERROR, error);
 });
 
-client.on('connect', (connection) => {
+socketClient.on('connect', (connection) => {
+  socketConnectComplete = true;
   connectionObj = connection;
 
   emitter.emit(Constants.SOCKET_CONNECTION_SUCCESS);
 
-  connection.on('error', (error) => {
-    emitter.emit(Constants.SOCKET_LOST_ERROR, `Error while connecting to App Configuration server ${error.message}`);
+  connection.on('error', async (error) => {
+    logger.warning(`websocket: received error event. ${error.message} Retrying websocket connect in 15 seconds...`)
+    await new Promise(resolve => setTimeout(resolve, 15000));
+    emitter.emit(Constants.SOCKET_LOST_ERROR, error);
   });
 
-  connection.on('close', (result) => {
+  connection.on('close', async (result, description) => {
     if (result === Constants.CUSTOM_SOCKET_CLOSE_REASON_CODE) {
       // logger.log('Do Nothing');
     } else {
+      logger.warning(`websocket: received close event. ${result} ${description} Retrying websocket connect in 15 seconds...`)
+      await new Promise(resolve => setTimeout(resolve, 15000));
       emitter.emit(Constants.SOCKET_CONNECTION_CLOSE);
     }
   });
@@ -88,7 +99,7 @@ client.on('connect', (connection) => {
       });
       dataJson = JSON.parse(JSON.stringify(dataJson));
 
-      emitter.emit(Constants.SOCKET_MESSAGE_RECEIVED, `Message received from server ${JSON.stringify(dataJson)}`);
+      emitter.emit(Constants.SOCKET_MESSAGE_RECEIVED, `${JSON.stringify(dataJson)}`);
       emitter.emit(Constants.SOCKET_CALLBACK);
     } else {
       emitter.emit(Constants.SOCKET_MESSAGE_ERROR);
@@ -96,7 +107,32 @@ client.on('connect', (connection) => {
   });
 });
 
+function closeWebSocket() {
+  if (connectionObj && connectionObj.connected) {
+    connectionObj.close(Constants.CUSTOM_SOCKET_CLOSE_REASON_CODE);
+  }
+}
+
+async function connectWebSocket() {
+  try {
+    if (socketConnectComplete === false) return;
+    socketConnectComplete = false;
+    const urlForWebsocket = urlBuilder.getWebSocketUrl();
+    const _bearerToken = await getToken();
+    const headers = {
+      Authorization: _bearerToken,
+      'User-Agent': `appconfiguration-node-sdk/${pkg.version}`
+    };
+    closeWebSocket(); // close existing websocket connection if any
+    socketClient.connect(
+      urlForWebsocket, [], [], headers,
+    );
+  } catch (e) {
+    logger.warning(`WebSocket connect request to the App Configuration server failed with unexpected error ${e}`);
+  }
+}
+
 module.exports = {
-  socketClient: client,
-  closeWebSocket,
+  connectWebSocket,
+  socketClient, // exported only for testing purpose
 };

--- a/lib/core/UrlBuilder.js
+++ b/lib/core/UrlBuilder.js
@@ -33,6 +33,7 @@ const UrlBuilder = () => {
   let _apikey = null;
   let _overrideServiceUrl = null;
   let _usePrivateEndpoint = false;
+  let _webSocketFullUrl = null;
 
   /**
    * Set the region value
@@ -124,13 +125,12 @@ const UrlBuilder = () => {
   };
 
   /**
-   * Get the websocket url
-   * @method module:UrlBuilder#getWebSocketUrl
+   * Set the websocket url
+   * @method module:UrlBuilder#setWebSocketUrl
    * @param {String} collectionId - The collection Id
    * @param {String} environmentId - The environment Id
-   * @returns {String} The websocket url
    */
-  const getWebSocketUrl = (collectionId, environmentId) => {
+  const setWebSocketUrl = (collectionId, environmentId) => {
     let ws = _webSocket;
 
     // for dev & stage
@@ -148,8 +148,15 @@ const UrlBuilder = () => {
       ws += _region;
       ws += _baseUrl;
     }
-    return `${ws + _service + wsUrl}?instance_id=${_instanceGuid}&collection_id=${collectionId}&environment_id=${environmentId}`;
+    _webSocketFullUrl = `${ws + _service + wsUrl}?instance_id=${_instanceGuid}&collection_id=${collectionId}&environment_id=${environmentId}`;
   };
+
+  /**
+   * Get the websocket url
+   * @method module:UrlBuilder#getWebSocketUrl
+   * @returns {String} The websocket url
+   */
+  const getWebSocketUrl = () => _webSocketFullUrl;
 
   /**
    * Use the private endpoint to connect to App Configuration service instance
@@ -174,6 +181,7 @@ const UrlBuilder = () => {
       getIamUrl,
       getBaseServiceUrl,
       getWebSocketUrl,
+      setWebSocketUrl,
       usePrivateEndpoint,
     };
   }

--- a/test/unit/configurations/internal/socket.test.js
+++ b/test/unit/configurations/internal/socket.test.js
@@ -19,6 +19,6 @@ const { socketClient } = require('../../../../lib/configurations/internal/Socket
 describe('websocket connect', () => {
   jest.setTimeout(30000);
   test('socket connect events', () => {
-    expect(socketClient.eventNames().length).toEqual(2);
+    expect(socketClient.eventNames().length).toEqual(3);
   });
 });

--- a/test/unit/core/urlbuilder.test.js
+++ b/test/unit/core/urlbuilder.test.js
@@ -20,6 +20,7 @@ const urlBuilder = UrlBuilder.getInstance();
 urlBuilder.setRegion('region');
 urlBuilder.setGuid('guid');
 urlBuilder.setBaseServiceUrl('https://my.custom.domain');
+urlBuilder.setWebSocketUrl('collection_id', 'environment_id');
 
 const expectedIamUrl = 'https://iam.test.cloud.ibm.com';
 const expectedSocketUrl = 'wss://my.custom.domain/apprapp/wsfeature?instance_id=guid&collection_id=collection_id&environment_id=environment_id';
@@ -33,14 +34,15 @@ describe('url builder', () => {
     expect(urlBuilder.getBaseServiceUrl()).toBe(expectedBaseServiceUrl);
   });
   test('socket url', () => {
-    expect(urlBuilder.getWebSocketUrl('collection_id', 'environment_id')).toBe(expectedSocketUrl);
+    expect(urlBuilder.getWebSocketUrl()).toBe(expectedSocketUrl);
   });
   test('private endpoint url', () => {
     urlBuilder.usePrivateEndpoint(true);
     urlBuilder.setBaseServiceUrl(null);
+    urlBuilder.setWebSocketUrl('collection_id', 'environment_id');
     let expectedPrivateBaseServiceUrl = 'https://private.region.apprapp.cloud.ibm.com';
     let expectedPrivateSockerUrl = 'wss://private.region.apprapp.cloud.ibm.com/apprapp/wsfeature?instance_id=guid&collection_id=collection_id&environment_id=environment_id';
     expect(urlBuilder.getBaseServiceUrl()).toBe(expectedPrivateBaseServiceUrl);
-    expect(urlBuilder.getWebSocketUrl('collection_id', 'environment_id')).toBe(expectedPrivateSockerUrl);
+    expect(urlBuilder.getWebSocketUrl()).toBe(expectedPrivateSockerUrl);
   });
 });


### PR DESCRIPTION
- Added flag check and prevented multiple synchronous websocket connect requests. This ensures unless a ongoing socket dial is complete, no another socket connect will be initiated.
- Added delays to socket reconnect upon `error`, `close` & `connectFailed` events. A time of 15 seconds will be waited before triggering another connect request.
- User agent is added to socket dial request
- Didn't increase the package version, because it was already increased in the previous PR #29 which is still unpublished. This PR changes will be clubbed and released as v0.5.1