### PR TITLE
added async/await for setContext, removed deprecated params

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-08-25T10:45:02Z",
+  "generated_at": "2023-09-15T06:58:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/examples/app.js
+++ b/examples/app.js
@@ -19,15 +19,7 @@ const express = require('express');
 const { AppConfiguration } = require('ibm-appconfiguration-node-sdk');
 
 const app = express();
-const region = process.env.REGION;
-const guid = process.env.GUID;
-const apikey = process.env.APIKEY;
-const collectionId = process.env.COLLECTION_ID;
-const environmentId = process.env.ENVIRONMENT_ID;
-
 const client = AppConfiguration.getInstance();
-client.init(region, guid, apikey);
-client.setContext(collectionId, environmentId);
 
 const entityId = 'user123';
 const entityAttributes = {
@@ -123,6 +115,20 @@ app.get('/getproperties', (req, res) => {
   res.json(allProperties);
 });
 
-app.listen(3000, () => {
+const region = process.env.REGION;
+const guid = process.env.GUID;
+const apikey = process.env.APIKEY;
+const collectionId = process.env.COLLECTION_ID;
+const environmentId = process.env.ENVIRONMENT_ID;
+
+app.listen(3000, async () => {
+  try {
+    client.init(region, guid, apikey);
+    await client.setContext(collectionId, environmentId);
+    console.log("app configuration sdk init successful");
+  } catch (e) {
+    console.error("failed to initialise app configuration sdk", e);
+  }
+
   console.log('app is running on port 3000....');
 });

--- a/lib/AppConfiguration.js
+++ b/lib/AppConfiguration.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+const path = require('path');
 const {
   Logger,
 } = require('./core/Logger');
@@ -29,6 +30,7 @@ const {
 const {
   configurationHandler,
 } = require('./configurations/ConfigurationHandler');
+const { reportError } = require('./configurations/internal/Utils');
 
 
 /**
@@ -53,14 +55,15 @@ const AppConfiguration = () => {
 
     /**
      * Initialize the sdk to connect with your App Configuration service instance.
-     * The method returns `null` if any of the params are missing or invalid.
      *
      * @method module:AppConfiguration#init
      * @param {string} region - REGION name where the App Configuration service instance is
      * created.
      * @param {string} guid - GUID of the App Configuration service.
      * @param {string} apikey - APIKEY of the App Configuration service.
-     * @returns {*}
+     * 
+     * @returns {void} This method does not return anything.
+     * @throws {Error} Throws an error with a custom message if any of the params are missing or invalid.
      */
     function init(region, guid, apikey) {
       // `init` is a sdk initialisation method. It is expected to be called only once.
@@ -69,40 +72,35 @@ const AppConfiguration = () => {
 
       if (!region || !guid || !apikey) {
         if (!region) {
-          logger.error(Constants.REGION_ERROR);
+          reportError(Constants.REGION_ERROR);
         } else if (!guid) {
-          logger.error(Constants.GUID_ERROR);
+          reportError(Constants.GUID_ERROR);
         } else {
-          logger.error(Constants.APIKEY_ERROR);
+          reportError(Constants.APIKEY_ERROR);
         }
-        return;
       }
 
       configurationHandlerInstance = configurationHandler.getInstance();
       configurationHandlerInstance.init(region, guid, apikey, _usePrivateEndpoint);
-
       isInitialized = true;
     }
 
     /**
      * Sets the context of the SDK
-     * Returns `null` if init is not performed before calling this method.
-     * Returns `null` if `collectionId` is not passed
-     * Returns `null` if `environmentId` is not passed
-     *
+     * Throws `Error` if init method was not called before calling this method.
+     * Throws `Error` if `collectionId` is not passed or invalid
+     * Throws `Error` if `environmentId` is not passed or invalid
+     * Throws `Error` if values passed in `options` param are invalid.
+     * Throws `Error` if there is an error fetching the configurations (i.e., feature flags & properties).
+     * 
+     * @async
      * @method module:AppConfiguration#setContext
      * @param {string} collectionId - Id of the collection created in App Configuration service
      * instance.
      * @param {string} environmentId - Id of the environment created in App Configuration
      * service instance.
-     * @param {string} [configurationFile=''] - DEPRECATED (use this param as part of `options` object):
-     * local configuration file path. This optional parameter when passed along with `liveConfigUpdateEnabled`
-     * value will drive the SDK to use local configuration file to perform feature & property evaluations.
-     * @param {boolean} [liveConfigUpdateEnabled=true] - DEPRECATED (use this param as part of `options` object):
-     * live configurations update from the server. Set this value to `false` if the new configuration values
-     * shouldn't be fetched from the server.
-     * @param {object} [options] - Options object
-     * @param {string} [options.persistentCacheDirectory] - The SDK will create a file - 'AppConfiguration.json'
+     * @param {object} [options] - A JSON object.
+     * @param {string} [options.persistentCacheDirectory] - The SDK will create a file - 'appconfiguration.json'
      * in the specified directory and it will be used as the persistent cache to store the App Configuration
      * service information.
      * @param {string} [options.bootstrapFile] - Absolute path of configuration file. This parameter
@@ -110,82 +108,70 @@ const AppConfiguration = () => {
      * present in this file to perform feature & property evaluations.
      * @param {boolean} [options.liveConfigUpdateEnabled] - live configurations update from the server.
      * Set this value to `false` if the new configuration values shouldn't be fetched from the server.
-     * @returns {*}
+     * 
+     * @returns {Promise<void>} A empty Promise that resolves when the configurations are successfully fetched or loaded.
+     * @throws {Error} If there is an error fetching the configurations (i.e., feature flags & properties).
      * @see init
      */
-    function setContext(collectionId, environmentId, ...args) {
+    async function setContext(collectionId, environmentId, options) {
       // `setContext` is also a sdk initialisation method. It is expected to be called only once.
       // Below if-condition makes sure the `setContext` inputs are taken only once even if this function is called mutiple times.
       if (isInitializedConfig) return;
 
       if (!isInitialized) {
-        logger.error(Constants.COLLECTION_ID_ERROR);
-        return;
+        reportError(Constants.COLLECTION_ID_ERROR);
       }
 
       if (!collectionId) {
-        logger.error(Constants.COLLECTION_ID_VALUE_ERROR);
-        return;
+        reportError(Constants.COLLECTION_ID_VALUE_ERROR);
       }
 
       if (!environmentId) {
-        logger.error(Constants.ENVIRONMENT_ID_VALUE_ERROR);
-        return;
+        reportError(Constants.ENVIRONMENT_ID_VALUE_ERROR);
       }
 
-      // default options (in-memory cache)
-      let options = {
+      const defaultOptions = {
         persistentCacheDirectory: null,
         bootstrapFile: null,
         liveConfigUpdateEnabled: true,
       };
-      const numberOfArguments = args.length;
-      configurationHandlerInstance = configurationHandler.getInstance();
 
-      switch (numberOfArguments) {
-        case 0:
-          // do nothing. (follow the in-memory cache)
-          break;
-        case 1:
-          // with just one parameter, it can be just configurationFile's string path or the options object.
-          // Do a condition check before proceeding. Only until we remove support for configurationFile
-          if (typeof (args[0]) === 'string') {
-            logger.info(Constants.DEPRECATION_MESSAGE_SETCONTEXT);
-            [options.bootstrapFile] = args;
-            break;
+      if (options !== undefined) {
+        if (options === null || typeof options !== 'object') {
+          reportError(`${Constants.INVALID_OPTIONS_PARAMTER}`);
+        }
+        if (Object.prototype.hasOwnProperty.call(options, 'persistentCacheDirectory')) {
+          const givenDirPath = options.persistentCacheDirectory;
+          if (typeof givenDirPath === 'string' && givenDirPath.length > 0) {
+            defaultOptions.persistentCacheDirectory = givenDirPath;
+          } else {
+            reportError(`${Constants.PERSISTENT_CACHE_OPTION_ERROR} ${givenDirPath}`);
           }
-          // all the optional parameters when passed in an json
-          [options] = args;
-          options.persistentCacheDirectory = options.persistentCacheDirectory ? options.persistentCacheDirectory : null;
-          options.bootstrapFile = options.bootstrapFile ? options.bootstrapFile : null;
-          options.liveConfigUpdateEnabled = (options.liveConfigUpdateEnabled === true || options.liveConfigUpdateEnabled === false)
-            ? options.liveConfigUpdateEnabled : true;
-          break;
-        case 2:
-          // case to support existing parameters `configurationFile` and `liveConfigUpdateEnabled`
-          logger.info(Constants.DEPRECATION_MESSAGE_SETCONTEXT);
-          [options.bootstrapFile, options.liveConfigUpdateEnabled] = args;
-          if (!options.liveConfigUpdateEnabled && !options.bootstrapFile) {
-            logger.error(Constants.CONFIGURATION_FILE_NOT_FOUND_ERROR);
-            return;
+        }
+        if (Object.prototype.hasOwnProperty.call(options, 'bootstrapFile')) {
+          const givenFilePath = options.bootstrapFile;
+          if (typeof givenFilePath === 'string' && givenFilePath.length > 0 && path.extname(givenFilePath) === '.json') {
+            defaultOptions.bootstrapFile = givenFilePath;
+          } else {
+            reportError(`${Constants.BOOTSTRAP_FILEPATH_OPTION_ERROR} ${givenFilePath}`);
           }
-          break;
-        case 3:
-          // when both (existing parameters & options object) are passed. The parameters in the options object
-          // takes precedence
-          [, , options] = args;
-          options.persistentCacheDirectory = options.persistentCacheDirectory ? options.persistentCacheDirectory : null;
-          options.bootstrapFile = options.bootstrapFile ? options.bootstrapFile : null;
-          options.liveConfigUpdateEnabled = (options.liveConfigUpdateEnabled === true || options.liveConfigUpdateEnabled === false)
-            ? options.liveConfigUpdateEnabled : true;
-          break;
-        default:
-          logger.error(Constants.ILLEGAL_ARGUMENTS);
-          return;
+        }
+        if (Object.prototype.hasOwnProperty.call(options, 'liveConfigUpdateEnabled')) {
+          const givenFlagValue = options.liveConfigUpdateEnabled;
+          if (typeof givenFlagValue === 'boolean') {
+            defaultOptions.liveConfigUpdateEnabled = givenFlagValue;
+          } else {
+            reportError(`${Constants.LIVE_CONFIG_UPDATE_OPTION_ERROR} ${givenFlagValue}`);
+          }
+        }
+        if (defaultOptions.liveConfigUpdateEnabled === false && defaultOptions.bootstrapFile === null) {
+          reportError(Constants.CONFIGURATION_FILE_NOT_FOUND_ERROR);
+        }
       }
 
       isInitializedConfig = true;
-      configurationHandlerInstance.setContext(collectionId, environmentId, options);
+      configurationHandlerInstance = configurationHandler.getInstance();
+      await configurationHandlerInstance.setContext(collectionId, environmentId, defaultOptions);
     }
 
     /**

--- a/lib/configurations/ConfigurationHandler.js
+++ b/lib/configurations/ConfigurationHandler.js
@@ -32,7 +32,7 @@ const { Segment } = require('./models/Segment');
 const { SegmentRules } = require('./models/SegmentRules');
 const { SecretProperty } = require("./models/SecretProperty");
 const { FileManager } = require('./internal/FileManager');
-const { getNormalizedValue } = require('./internal/Utils');
+const { getNormalizedValue, reportError } = require('./internal/Utils');
 const { connectWebSocket } = require('./internal/Socket');
 const { events } = require('./internal/Events');
 const { Constants } = require('./internal/Constants');
@@ -80,17 +80,7 @@ const ConfigurationHandler = () => {
    * @method module:ConfigurationHandler#createInstance
    */
   function createInstance() {
-    /**
-     * Initialize the configuration.
-     *
-     * @method module:ConfigurationHandler#init
-     * @param {string} region - REGION name where the App Configuration service instance is
-     * created.
-     * @param {string} guid - GUID of the App Configuration service.
-     * @param {string} apikey - APIKEY of the App Configuration service.
-     * @param {boolean} usePrivateEndpoint - If true, use private endpoint to connect to 
-     * App Configuration service instance.
-     */
+
     function init(region, guid, apikey, usePrivateEndpoint) {
       _guid = guid;
       urlBuilder.setRegion(region);
@@ -151,38 +141,29 @@ const ConfigurationHandler = () => {
     }
 
     /**
-     * Writes the given data on to the persistent volume.
+     * Asynchronously writes the given data on to the persistent volume.
      *
      * @async
      * @param {JSON|string} fileData - The data to be written
-     * @returns {undefined} If fileData is null
+     * @throws {Error} If fails to write due to insufficient permissions or other reasons.
      */
-    async function writeToPersistentStorage(fileData) {
-      if (fileData == null) {
-        logger.log('No data');
-        return;
-      }
+    function writeToPersistentStorage(fileData) {
       const json = JSON.stringify(fileData);
       FileManager.storeFiles(json, (path.join(_persistentCacheDirectory, 'appconfiguration.json')), () => { });
     }
 
     /**
-     * Creates API request and waits for the response.
-     * If response has data, then passes the response data to `writeToPersistentStorage()` method
-     * for further actions. Else, logs the error message to console.
-     *
      * @async
      * @method module:ConfigurationHandler#fetchFromAPI
      */
     async function fetchFromAPI() {
-      const query = {
-        environment_id: _environmentId,
-      };
       const parameters = {
         options: {
           url: `/apprapp/feature/v1/instances/${_guid}/collections/${_collectionId}/config`,
           method: 'GET',
-          qs: query,
+          qs: {
+            environment_id: _environmentId,
+          },
         },
         defaultOptions: {
           serviceUrl: urlBuilder.getBaseServiceUrl(),
@@ -204,36 +185,38 @@ const ConfigurationHandler = () => {
       // For 429 error code - The createRequest() will retry the request 3 times in an interval of time mentioned in ["retry-after"] header.
       // If all the 3 retries exhausts the "await" gets completed. The execution goes to catch block
       //
-      // Both the cases [429 & 5xx] we schedule a retry after 10 minutes.
+      // For the cases [429, 499 & 5xx] we schedule a retry.
 
       let _response;
 
       try {
         _response = await getBaseServiceClient().createRequest(parameters);
-      } catch (_exception) {
-        logger.error(`${Constants.ERROR_FETCH_FROM_API}. ${_exception}`);
-        if ((_exception.status >= Constants.STATUS_CODE_SERVER_ERROR_BEGIN && _exception.status <= Constants.STATUS_CODE_SERVER_ERROR_END) ||
-          (_exception.status === Constants.STATUS_CODE_TOO_MANY_REQUESTS) ||
-          (_exception.status === Constants.STATUS_CODE_CLIENT_SIDE_TIMEOUT) ||
-          (_exception.status === undefined)) {
-          logger.error(`Failed to fetch the configurations. Retrying again after ${retryTime} minutes`);
-          retryScheduled = setTimeout(() => fetchFromAPI(), retryTime * 60000);
+      } catch (e) {
+        const statusCode = e.status;
+        const errMsg = "Failed to fetch the configurations.";
+        if (statusCode >= 400 && statusCode < 499 && statusCode !== 429) {
+          // 'Do Nothing! GET "/config" failed due to client-side error.
+          logger.error(`${errMsg} ${e.message ? e.message : e}`);
+          return;
         }
+        logger.warning(`${errMsg} ${e.message ? e.message : e} Retrying in ${retryTime} minutes...`);
+        clearTimeout(retryScheduled);
+        retryScheduled = setTimeout(() => fetchFromAPI(), retryTime * 60000);
         return;
       }
 
-      if (_response && _response.status === Constants.STATUS_CODE_OK) {
-        logger.log(Constants.SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS);
-        // load the configurations in the response to cache maps
-        loadConfigurationsToCache(_response.result);
-        emitter.emit(Constants.MEMORY_CACHE_ACTION_SUCCESS);
-        // asynchronously write the response to persistent volume, if enabled
-        if (_persistentCacheDirectory) {
+      // a) load the configurations in the response to cache maps
+      // b) asynchronously write the response to persistent volume, if enabled
+
+      logger.log(`${Constants.SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS}. Status code:${_response.status}`);
+      loadConfigurationsToCache(_response.result);
+      emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
+      if (_persistentCacheDirectory) {
+        try {
           writeToPersistentStorage(_response.result);
+        } catch (e) {
+          logger.error(`Failed to write the configurations to persistent storage. Reason: ${e}`);
         }
-      } else {
-        // rare or impossible case
-        logger.error(`Failed to fetch the configurations due to unknown reasons. ${_response}`);
       }
     }
 
@@ -244,57 +227,45 @@ const ConfigurationHandler = () => {
       return false;
     }
 
-    async function fetchConfigurationsData() {
-      if (_liveUpdate) {
-        await fetchFromAPI();
+    function beginWebsocketAndCheckInternet() {
+      urlBuilder.setWebSocketUrl(_collectionId, _environmentId);
+      setTimeout(() => {
         connectWebSocket();
-      }
+      }, 2000);
+
+      interval = setInterval(() => {
+        checkInternet().then((val) => {
+          if (!val) {
+            logger.warning(Constants.NO_INTERNET_CONNECTION_ERROR);
+            _isConnected = false;
+          } else {
+            if (!_isConnected) {
+              _onSocketRetry = false;
+              fetchFromAPI();
+              connectWebSocket();
+            }
+            _isConnected = true;
+          }
+        });
+      }, 30000); // 30 second
     }
 
-    /**
-     *  Sets the context of the SDK
-     *
-     * @method module:ConfigurationHandler#setContext
-     * @param {string} collectionId - Id of the collection created in App Configuration service
-     * instance.
-     * @param {string} environmentId - Id of the environment created in App Configuration
-     * service instance.
-     * @param {object} [options] - Options object
-     * @param {string} [options.persistentCacheDirectory] - Absolute path to a directory which has
-     * read & write permissions for file operations.
-     * @param {string} [options.bootstrapFile] - Absolute path of configuration file. This parameter
-     * when passed along with `liveConfigUpdateEnabled` value will drive the SDK to use the
-     * configurations of this file to perform feature & property evaluations.
-     * @param {boolean} [options.liveConfigUpdateEnabled] - live configurations update from the server.
-     * Set this value to `false` if the new configuration values shouldn't be fetched from the server.
-     */
-    function setContext(collectionId, environmentId, options) {
-      // when setContext is called more than one time with any of collectionId, environmentId or options
-      // different from its previous time, cleanup method is invoked.
-      // don't do the cleanup when setContext is called for the first time.
-      if ((_collectionId && (_collectionId !== collectionId))
-        || (_environmentId && (_environmentId !== environmentId))
-        || (_persistentCacheDirectory && (_persistentCacheDirectory !== options.persistentCacheDirectory))
-        || (_bootstrapFile && (_bootstrapFile !== options.bootstrapFile))
-      ) {
-        cleanup();
-      }
+    async function setContext(collectionId, environmentId, options) {
       _collectionId = collectionId;
       _environmentId = environmentId;
       _persistentCacheDirectory = options.persistentCacheDirectory;
       _bootstrapFile = options.bootstrapFile;
       _liveUpdate = options.liveConfigUpdateEnabled;
-      urlBuilder.setWebSocketUrl(_collectionId, _environmentId);
 
       if (_persistentCacheDirectory) {
-        persistentData = FileManager.getFileData(path.join(_persistentCacheDirectory, 'appconfiguration.json'));
-        // no emitting the event here. Only updating cache is enough
+        logger.info(`persistent cache directory path is: ${_persistentCacheDirectory}`);
+        const filePath = path.join(_persistentCacheDirectory, 'appconfiguration.json');
+        persistentData = FileManager.readPersistentCacheConfigurations(filePath);
         loadConfigurationsToCache(persistentData);
         try {
           fs.accessSync(_persistentCacheDirectory, fs.constants.W_OK);
         } catch (err) {
-          logger.error(Constants.ERROR_NO_WRITE_PERMISSION);
-          return;
+          reportError(`${Constants.ERROR_NO_WRITE_PERMISSION} ${err}`);
         }
       }
 
@@ -302,49 +273,84 @@ const ConfigurationHandler = () => {
         if (_persistentCacheDirectory) {
           if (isJSONDataEmpty(persistentData)) {
             try {
-              const bootstrapFileData = FileManager.getFileData(_bootstrapFile);
+              const bootstrapFileData = FileManager.readBootstrapConfigurations(_bootstrapFile);
               loadConfigurationsToCache(bootstrapFileData);
-              emitter.emit(Constants.MEMORY_CACHE_ACTION_SUCCESS);
               writeToPersistentStorage(bootstrapFileData);
-            } catch (error) {
-              logger.error(error);
+              if (!_liveUpdate) emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
+            } catch (e) {
+              reportError(e);
             }
-          } else {
-            // only emit the event here. Because, cache is already updated above (line 270)
-            emitter.emit(Constants.MEMORY_CACHE_ACTION_SUCCESS);
-          }
+          } else if (!_liveUpdate) emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
         } else {
-          const bootstrapFileData = FileManager.getFileData(_bootstrapFile);
-          loadConfigurationsToCache(bootstrapFileData);
-          emitter.emit(Constants.MEMORY_CACHE_ACTION_SUCCESS);
+          logger.info(`reading configurations from bootstrap file: ${_bootstrapFile}`);
+          try {
+            const bootstrapFileData = FileManager.readBootstrapConfigurations(_bootstrapFile);
+            loadConfigurationsToCache(bootstrapFileData);
+            if (!_liveUpdate) emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
+          } catch (e) {
+            reportError(e);
+          }
         }
       }
 
       if (_liveUpdate) {
-        checkInternet().then((val) => {
-          if (!val) {
-            logger.warning(Constants.NO_INTERNET_CONNECTION_ERROR);
-            _isConnected = false;
-          }
-        });
-        interval = setInterval(() => {
-          checkInternet().then((val) => {
-            if (!val) {
-              logger.warning(Constants.NO_INTERNET_CONNECTION_ERROR);
-              _isConnected = false;
-            } else {
-              if (!_isConnected) {
-                _onSocketRetry = false;
-                fetchFromAPI();
-                connectWebSocket();
-              }
-              _isConnected = true;
-            }
-          });
-        }, 30000); // 30 second
-      }
+        const parameters = {
+          options: {
+            url: `/apprapp/feature/v1/instances/${_guid}/collections/${_collectionId}/config`,
+            method: 'GET',
+            qs: {
+              environment_id: _environmentId,
+            },
+          },
+          defaultOptions: {
+            serviceUrl: urlBuilder.getBaseServiceUrl(),
+            headers: getHeaders(),
+          },
+        };
 
-      fetchConfigurationsData();
+        let _response;
+        try {
+          _response = await getBaseServiceClient().createRequest(parameters);
+        } catch (e) {
+          const statusCode = e.status;
+          const errMsg = `Status code: ${statusCode}. Message: Failed to fetch the configurations from remote server. Reason: ${e}`;
+
+          if (statusCode >= 400 && statusCode < 499 && statusCode !== 429) {
+            reportError(errMsg);
+          }
+          if (_persistentCacheDirectory !== null && !isJSONDataEmpty(persistentData)) {
+            const message = `Loaded the configurations from the persistent storage: ${path.join(_persistentCacheDirectory, 'appconfiguration.json')} into the application.`
+            logger.info(`${errMsg}. ${message}`);
+            emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER, message);
+            beginWebsocketAndCheckInternet();
+            return;
+          }
+          if (_bootstrapFile !== null) {
+            const message = `Loaded the configurations from the bootstrap file: ${_bootstrapFile} into the application.`;
+            logger.info(`${errMsg}. ${message}`);
+            emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER, message);
+            beginWebsocketAndCheckInternet();
+            return;
+          }
+          reportError(errMsg);
+        }
+
+        logger.log(`${Constants.SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS}. Status code:${_response.status}`);
+        loadConfigurationsToCache(_response.result);
+        emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
+        if (_persistentCacheDirectory) {
+          // asynchronously write the response to persistent volume, if enabled
+          try {
+            writeToPersistentStorage(_response.result);
+          } catch (e) {
+            logger.error(`fetched configurations could not be written to persistent storage. Reason: ${e}`);
+            // not throwing any error as SDK now has all the configurations needed for feature flag & property evaluation.
+            // Errors such as persistent cache path not found or write permission denied would have already thrown error before execution is reached here.
+          }
+        }
+
+        beginWebsocketAndCheckInternet();
+      }
     }
 
     async function socketActions() {
@@ -654,11 +660,6 @@ const ConfigurationHandler = () => {
       }
     }
 
-    // Other event listeners
-    emitter.on(Constants.MEMORY_CACHE_ACTION_SUCCESS, () => {
-      emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
-    });
-
     // Socket Listeners
     emitter.on(Constants.SOCKET_CONNECTION_ERROR, () => {
       _onSocketRetry = true;
@@ -683,12 +684,12 @@ const ConfigurationHandler = () => {
       socketActions();
     });
 
-    emitter.on(Constants.SOCKET_MESSAGE_ERROR, () => {
-      logger.warning('Message received from server is invalid.');
+    emitter.on(Constants.SOCKET_MESSAGE_ERROR, (messageType) => {
+      logger.error(`Invalid message received from websocket connection. Message type: ${messageType}`);
     });
 
     emitter.on(Constants.SOCKET_CONNECTION_SUCCESS, () => {
-      logger.log('Successfully connected to App Configuration server');
+      logger.log('Successfully established websocket connection with App Configuration server.');
       if (_onSocketRetry === true) {
         socketActions();
       }

--- a/lib/configurations/internal/Constants.js
+++ b/lib/configurations/internal/Constants.js
@@ -31,7 +31,6 @@ const Constants = {
   SOCKET_CALLBACK: 'Message passed to handler',
   SOCKET_MESSAGE_ERROR: 'Message received from server is invalid',
   SOCKET_CONNECTION_SUCCESS: 'Successfully connected to App Configuration server',
-  MEMORY_CACHE_ACTION_SUCCESS: 'memoryCacheUpdated',
   APPCONFIGURATION_CLIENT_EMITTER: 'configurationUpdate',
 
   // Other constants
@@ -42,8 +41,13 @@ const Constants = {
   ENVIRONMENT_ID_VALUE_ERROR: 'Provide a valid environmentId in App Configuration setContext method.',
   COLLECTION_ID_ERROR: 'Invalid action in App Configuration. This action can be performed only after a successful initialization. \n Please check the initialization section for errors.',
   COLLECTION_INIT_ERROR: 'Invalid action in App Configuration. This action can be performed only after a successful initialization and setting the context. \n Please check the initialization and setContext sections for errors.',
-  CONFIGURATION_FILE_NOT_FOUND_ERROR: 'configurationFile parameter should be provided while liveConfigUpdateEnabled is false during initialization.',
-  NO_INTERNET_CONNECTION_ERROR: 'No connection to internet. Please re-connect.',
+  INVALID_OPTIONS_PARAMTER: 'options param passed to setContext is invalid. Should be a JSON',
+  CONFIGURATION_FILE_NOT_FOUND_ERROR: 'bootstrapFile parameter should be provided while liveConfigUpdateEnabled is false during initialization.',
+  PERSISTENT_CACHE_OPTION_ERROR: 'setContext: [options.persistentCacheDirectory]. Invalid value -',
+  BOOTSTRAP_FILEPATH_OPTION_ERROR: 'setContext: [options.bootstrapFile]. Invalid value -',
+  LIVE_CONFIG_UPDATE_OPTION_ERROR: 'setContext: [options.liveConfigUpdateEnabled]. Invalid value -',
+  BOOTSTRAP_FILEPATH_NOT_FOUND_ERROR: 'setContext: [options.bootstrapFile] parameter should be provided when [options.liveConfigUpdateEnabled] is false.',
+  NO_INTERNET_CONNECTION_ERROR: 'Check for network connectivity failed. Re-checking...',
   INVALID_ENTITY_ID: 'Invalid entityId passed to', // a substring of the entire message
   SINGLETON_EXCEPTION: 'Initialize object first',
   DEFAULT_SEGMENT_ID: '$$null$$',
@@ -53,24 +57,15 @@ const Constants = {
   DEFAULT_FEATURE_VALUE: '$default',
   DEFAULT_PROPERTY_VALUE: '$default',
   INVALID_SECRET_MANAGER_CLIENT_MESSAGE: 'Secret Manager object passed to getSecret method is null or undefined.',
-  SECRETREF : 'SECRETREF',
+  SECRETREF: 'SECRETREF',
   SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS: 'Successfully fetched the configurations',
   ERROR_POSTING_METERING_DATA: 'Error while posting metering data',
   SUCCESSFULLY_POSTED_METERING_DATA: 'Successfully posted metering data',
-  ERROR_FETCH_FROM_API: 'Error while getting configurations data',
   ERROR_NO_WRITE_PERMISSION: 'Persistent cache directory provided doesn\'t have write permission. Make sure the directory has required access.',
-  CREATE_NEW_CONNECTION: 'Retrying to create a new connection',
-  DEPRECATION_MESSAGE_SETCONTEXT: 'Deprecated: With v0.2.0 onwards, the configurationFile and liveConfigUpdateEnabled parameters of setContext method have been deprecated. '
-    + 'Use options parameter instead.',
-  ILLEGAL_ARGUMENTS: 'Illegal number of arguments provided to setContext method.',
   INPUT_PARAMETER_NOT_BOOLEAN: 'Input parameter passed to usePrivateEndpoint() method is not boolean. Default value will be used.',
   MAX_NUMBER_OF_RETRIES: 3,
   STATUS_CODE_OK: 200,
   STATUS_CODE_ACCEPTED: 202,
-  STATUS_CODE_TOO_MANY_REQUESTS: 429,
-  STATUS_CODE_CLIENT_SIDE_TIMEOUT: 499,
-  STATUS_CODE_SERVER_ERROR_BEGIN: 500,
-  STATUS_CODE_SERVER_ERROR_END: 599,
 };
 
 module.exports = {

--- a/lib/configurations/internal/FileManager.js
+++ b/lib/configurations/internal/FileManager.js
@@ -31,47 +31,72 @@ const logger = Logger.getInstance();
  * Store/copy the given data to specified filepath
  *
  * @method module:FileManager#storeFiles
- * @param {string|object} json - The data to be stored
+ * @param {string} json - The data to be stored
  * @param {string} filePath - File path where the data should be stored
  * @param {Function} callback
+ * 
+ * @returns {void} This method does not return anything.
+ * @throws {Error} If fails to write to given filePath due to insufficient permissions or other reasons.
  */
 function storeFiles(json, filePath, callback) {
-  try {
-    fs.writeFile(filePath, json, 'utf-8', (err) => {
-      if (err) {
-        throw Error(err);
-      } else {
-        logger.log('Stored configurations to persistent storage');
-        callback();
-      }
-    });
-  } catch (error) {
-    logger.warning(error.message);
-  }
+  fs.writeFile(filePath, json, 'utf-8', (err) => {
+    if (err) {
+      throw Error(err.message);
+    } else {
+      callback();
+    }
+  });
 }
 
 /**
- * Read the data from the given file path.
+ * Read configurations from the persistent file.
  *
- * @method module:FileManager#getFileData
- * @param {string} filePath - File path from where the data should be read
- * @returns Contents of the file
+ * @method module:FileManager#readPersistentCacheConfigurations
+ * @param {string} filePath - persistent file path from where the configurations data should be read
+ * 
+ * @returns {JSON} JSON parsed configurations from the given file path or empty json.
  */
-function getFileData(filePath) {
+function readPersistentCacheConfigurations(filePath) {
   let data = {};
   try {
     if (!fs.existsSync(filePath)) {
+      logger.log(`configuration file in the persistent cache doesn't exists`);
       return {};
     }
 
     data = fs.readFileSync(filePath, 'utf-8');
     if (!data) {
+      logger.log(`configuration file in the persistent cache is empty`);
       return {};
     }
     return JSON.parse(data);
-  } catch (error) {
-    logger.warning(error);
+  } catch (e) {
     return {};
+  }
+}
+
+/**
+ * Read bootstrap configurations from the given file path.
+ *
+ * @method module:FileManager#readBootstrapConfigurations
+ * @param {string} filePath - File path from where the configurations data should be read
+ * 
+ * @returns JSON parsed bootstrap configurations from the given file path, if there was no error reading it.
+ * @throws {Error} If filePath doesn't exists or is empty or fails to parse the json.
+ */
+function readBootstrapConfigurations(filePath) {
+  let data = {};
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`given bootstrap file path doesn't exist: ${filePath}`);
+  }
+  data = fs.readFileSync(filePath, 'utf-8');
+  if (!data) {
+    throw new Error(`given bootstrap file is empty: ${filePath}`);
+  }
+  try {
+    return JSON.parse(data);
+  } catch (err) {
+    throw new Error(`failed to parse the json from the given bootstrap file: ${filePath}. Error ${err}`)
   }
 }
 
@@ -94,7 +119,8 @@ function deleteFileData(filePath) {
 }
 
 module.exports.FileManager = {
-  getFileData,
+  readBootstrapConfigurations,
+  readPersistentCacheConfigurations,
   storeFiles,
   deleteFileData,
 };

--- a/lib/configurations/internal/Socket.js
+++ b/lib/configurations/internal/Socket.js
@@ -102,7 +102,7 @@ socketClient.on('connect', (connection) => {
       emitter.emit(Constants.SOCKET_MESSAGE_RECEIVED, `${JSON.stringify(dataJson)}`);
       emitter.emit(Constants.SOCKET_CALLBACK);
     } else {
-      emitter.emit(Constants.SOCKET_MESSAGE_ERROR);
+      emitter.emit(Constants.SOCKET_MESSAGE_ERROR, message.type);
     }
   });
 });
@@ -128,7 +128,7 @@ async function connectWebSocket() {
       urlForWebsocket, [], [], headers,
     );
   } catch (e) {
-    logger.warning(`WebSocket connect request to the App Configuration server failed with unexpected error ${e}`);
+    logger.error(`WebSocket connect request to the App Configuration server failed with unexpected error ${e}`);
   }
 }
 

--- a/lib/configurations/internal/Utils.js
+++ b/lib/configurations/internal/Utils.js
@@ -15,6 +15,9 @@
  */
 
 const murmurhash = require('murmurhash');
+const { Logger } = require('../../core/Logger');
+
+const logger = Logger.getInstance();
 
 function computeHash(str) {
   const SEED = 0;
@@ -27,6 +30,12 @@ function getNormalizedValue(str) {
   return Math.floor((computeHash(str) / MAX_HASH_VALUE) * NORMALIZER);
 }
 
+function reportError(message) {
+  logger.error(message);
+  throw new Error(message);
+}
+
 module.exports = {
   getNormalizedValue,
+  reportError,
 };

--- a/lib/configurations/models/Feature.js
+++ b/lib/configurations/models/Feature.js
@@ -102,6 +102,7 @@ class Feature {
    * 
    * @returns {object|null} Returns a json object containing evaluated value, enabled status & detailed reason.
    * The evaluated value will be one of Enabled/Disabled/Overridden value based on the evaluation. The data type of evaluated value matches that of feature flag.
+   * Returns null if entityId is invalid.
    * 
    * Example: 
    * ```js

--- a/lib/configurations/models/Property.js
+++ b/lib/configurations/models/Property.js
@@ -90,6 +90,7 @@ class Property {
    * 
    * @returns {object|null} Returns a json object containing evaluated value & detailed reason.
    * The evaluated value will be either the default property value or its overridden value based on the evaluation. The data type of returned value matches that of property.
+   * Returns null if entityId is invalid.
    * 
    * Example:
    * ```js

--- a/lib/configurations/models/SecretProperty.js
+++ b/lib/configurations/models/SecretProperty.js
@@ -33,7 +33,7 @@ class SecretProperty {
    * @param {*} entityId - Id of the Entity.
    * @param {*} entityAttributes - A JSON object consisting of the attribute name and their values that defines the specified entity.
    * 
-   * @return {Promise|null} returns a Promise that either resolves with the response from the secret manager or rejects with an Error.
+   * @return {Promise|null} returns a Promise that either resolves with the response from the secret manager or rejects with an Error. Returns null if entityId is invalid.
    * The resolved value will be the actual secret value of the evaluated secret reference. The response contains the body, the headers, the status code, and the status text.
    * If using async/await, use try/catch for handling errors.
    */

--- a/lib/core/ApiManager.js
+++ b/lib/core/ApiManager.js
@@ -81,7 +81,12 @@ function getBaseServiceClient() {
  */
 async function getToken() {
   const options = {};
-  await _iamAuthenticator.authenticate(options);
+  try {
+    await _iamAuthenticator.authenticate(options);
+  } catch (e) {
+    const errMsg = `Failed to get authentication token for websocket connect. Error ${e}`
+    throw new Error(errMsg)
+  }
   return options.headers.Authorization; // will return the string "Bearer <token>"
 }
 

--- a/lib/core/UrlBuilder.js
+++ b/lib/core/UrlBuilder.js
@@ -133,15 +133,15 @@ const UrlBuilder = () => {
   const setWebSocketUrl = (collectionId, environmentId) => {
     let ws = _webSocket;
 
-    // for dev & stage
     if (_overrideServiceUrl) {
+      // for dev & stage
       const temp = _overrideServiceUrl.replace('https://', '').replace('http://', '');
       if (_usePrivateEndpoint) {
         ws += _privateEndpointPrefix;
       }
       ws += temp;
-      // for prod
     } else {
+      // for prod
       if (_usePrivateEndpoint) {
         ws += _privateEndpointPrefix;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ibm-appconfiguration-node-sdk",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "IBM Cloud App Configuration Node.js SDK",
   "main": "./lib/AppConfiguration.js",
   "scripts": {

--- a/test/unit/appconfiguration.test.js
+++ b/test/unit/appconfiguration.test.js
@@ -45,83 +45,94 @@ describe('feature & property methods before initialization', () => {
   test('getProperties', () => {
     expect(client.getProperties()).toBe(null);
   });
+  test('getSecret', () => {
+    expect(client.getSecret('property_id', null)).toBe(null);
+  });
 });
 
 describe('init method', () => {
   let client;
   test('no region', () => {
     client = initializeAppConfiguration();
-    expect(client.init(null, 'guid_value', 'apikey_value')).toBeUndefined();
+    expect(() => { client.init(null, 'guid_value', 'apikey_value'); }).toThrow(Error);
     client = null;
   });
   test('no guid', () => {
     client = initializeAppConfiguration();
-    expect(client.init('region_value', null, 'apikey_value')).toBeUndefined();
+    expect(() => { client.init('region_value', null, 'apikey_value'); }).toThrow(Error);
     client = null;
   });
   test('no apikey', () => {
     client = initializeAppConfiguration();
-    expect(client.init('region_value', 'guid_value', null)).toBeUndefined();
+    expect(() => { client.init('region_value', 'guid_value', null); }).toThrow(Error);
     client = null;
   });
 });
 
 describe('setContext method', () => {
   let client;
-  test('setContext without init method initialised', () => {
+  test('setContext without init method initialised', async () => {
     client = initializeAppConfiguration();
-    expect(client.setContext(null)).toBeUndefined();
+    await expect(client.setContext(null)).rejects.toThrow();
     client = null;
   });
 
-  test('no collection id', () => {
+  test('no collection id', async () => {
     client = initializeAppConfiguration();
     client.init('region_value', 'guid_value', 'apikey_value');
-    expect(client.setContext(null, 'environment_id')).toBeUndefined();
+    await expect(client.setContext(null, 'environment_id')).rejects.toThrow();
     client = null;
   });
 
-  test('no environment id', () => {
+  test('no environment id', async () => {
     client = initializeAppConfiguration();
     client.init('region_value', 'guid_value', 'apikey_value');
-    expect(client.setContext('collection_id', null)).toBeUndefined();
+    await expect(client.setContext('collection_id', null)).rejects.toThrow();
     client = null;
   });
 
-  test('test when illegal number of arguments are provided to setContext method', () => {
+  test('test setContext when persistent cache directory is not string', async () => {
     client = initializeAppConfiguration();
     client.init('region_value', 'guid_value', 'apikey_value');
-    expect(client.setContext('collection_id', 'environment_id', null, null, {
-      persistentCacheDirectory: __dirname,
-    })).toBeUndefined();
+    await expect(client.setContext('collection_id', 'environment_id', {
+      persistentCacheDirectory: true,
+    })).rejects.toThrow(Error);
     client = null;
   });
 
-  test('test offline mode by passing an empty string as config file path', async () => {
+  test('test setContext when bootstrap file is not string', async () => {
     client = initializeAppConfiguration();
     client.init('region_value', 'guid_value', 'apikey_value');
-    expect(client.setContext('collection_id', 'environment_id', null, false)).toBeUndefined();
+    await expect(client.setContext('collection_id', 'environment_id', {
+      bootstrapFile: 0,
+    })).rejects.toThrow(Error);
     client = null;
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+  });
+
+  test('test setContext when liveConfigUpdateEnabled is not boolean', async () => {
+    client = initializeAppConfiguration();
+    client.init('region_value', 'guid_value', 'apikey_value');
+    await expect(client.setContext('collection_id', 'environment_id', {
+      liveConfigUpdateEnabled: 0,
+    })).rejects.toThrow(Error);
+    client = null;
   });
 
   test('test when persistent cache is enabled', async () => {
     client = initializeAppConfiguration();
     client.init('region_value', 'guid_value', 'apikey_value');
-    client.setContext('collection_id', 'environment_id', {
+    await expect(client.setContext('collection_id', 'environment_id', {
       persistentCacheDirectory: __dirname,
-    })
+    })).rejects.toThrow(Error);
     client = null;
-    await new Promise((resolve) => setTimeout(resolve, 2000));
   });
 
   test('test in-memory cache only', async () => {
     client = initializeAppConfiguration();
     client.setDebug(true);
     client.init('region_value', 'guid_value', 'apikey_value');
-    client.setContext('collection_id', 'environment_id');
+    await expect(client.setContext('collection_id', 'environment_id')).resolves.toBeUndefined();
     client = null;
-    await new Promise((resolve) => setTimeout(resolve, 2000));
   });
   jest.clearAllTimers();
 });
@@ -139,5 +150,8 @@ describe('features & properties get methods', () => {
   });
   test('getProperties', () => {
     expect(client.getProperties()).toMatchObject({});
+  });
+  test('getSecret', () => {
+    expect(client.getSecret('property_id', null)).toBe(null);
   });
 });

--- a/test/unit/configurations/configuration_handler.test.js
+++ b/test/unit/configurations/configuration_handler.test.js
@@ -28,7 +28,6 @@ async function setup() {
     bootstrapFile: filePath,
     liveConfigUpdateEnabled: false,
   });
-  await new Promise((resolve) => setTimeout(resolve, 4000));
 }
 
 beforeAll(() => {
@@ -85,16 +84,16 @@ describe('configuration handler', () => {
     expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', {}).isEnabled).toBe(false);
     expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', { email: 'alice@ibm.com', band_level: '7' }).value).toBe(25);
     expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', { email: 'alice@ibm.com', band_level: '7' }).isEnabled).toBe(true);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', { email: 'alice@ibm.com',  band_level: '6' }).value).toBe(0);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', { email: 'alice@ibm.com',  band_level: '6' }).isEnabled).toBe(false);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', { email: 'alice@ibm.com', band_level: '6' }).value).toBe(0);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id1', { email: 'alice@ibm.com', band_level: '6' }).isEnabled).toBe(false);
     expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', {}).value).toBe(5);
     expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', {}).isEnabled).toBe(true);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'alice@ibm.com',  band_level: '7' }).value).toBe(25);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'alice@ibm.com',  band_level: '7' }).isEnabled).toBe(true);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'bob@ibm.com',  band_level: '7' }).value).toBe(5);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'bob@ibm.com',  band_level: '7' }).isEnabled).toBe(true);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id6', { email: 'bob@ibm.com',  band_level: '7' }).value).toBe(0);
-    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id6', { email: 'bob@ibm.com',  band_level: '7' }).isEnabled).toBe(false);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'alice@ibm.com', band_level: '7' }).value).toBe(25);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'alice@ibm.com', band_level: '7' }).isEnabled).toBe(true);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'bob@ibm.com', band_level: '7' }).value).toBe(5);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id2', { email: 'bob@ibm.com', band_level: '7' }).isEnabled).toBe(true);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id6', { email: 'bob@ibm.com', band_level: '7' }).value).toBe(0);
+    expect(configurationHandlerInstance.featureEvaluation(featureObj, 'id6', { email: 'bob@ibm.com', band_level: '7' }).isEnabled).toBe(false);
     expect(featureObj.isEnabled()).toBe(true);
     const result = featureObj.getCurrentValue('id1', { email: 'alice@ibm.com', band_level: '7' });
     expect(result.value).toBe(25);

--- a/test/unit/configurations/internal/filemanager.test.js
+++ b/test/unit/configurations/internal/filemanager.test.js
@@ -84,15 +84,21 @@ describe('file manager', () => {
     const filePath = path.join(__dirname, 'nonexistingfile.json');
     expect(FileManager.deleteFileData(filePath)).toBeUndefined();
   });
-  test('read config file', () => {
+  test('read config file - persistent cache', () => {
     const filePath = path.join(__dirname, 'nonexistingfile.json');
-    expect(FileManager.getFileData(filePath)).toStrictEqual({});
+    expect(FileManager.readPersistentCacheConfigurations(filePath)).toStrictEqual({});
   });
-  test('write & read config file', () => {
+  test('read config file - bootstrap configurations', () => {
+    const filePath = path.join(__dirname, 'nonexistingfile.json');
+    expect(() => { FileManager.readBootstrapConfigurations(filePath) }).toThrow(Error);
+  });
+  test('read config file - bootstrap configurations', () => {
+    const filePath = path.join(__dirname, 'appconfiguration.json');
+    expect(() => { FileManager.readBootstrapConfigurations(filePath) }).toThrow(Error);
+  });
+  test('write configurations to a file', () => {
     jest.setTimeout(30000);
     const filePath = path.join(__dirname, 'appconfiguration.json');
-    FileManager.storeFiles(data, filePath, () => {
-      expect(FileManager.getFileData(filePath)).toBe(data);
-    });
+    expect(() => { FileManager.storeFiles(data, filePath, () => { }) }).toThrow();
   });
 });


### PR DESCRIPTION
- await is added to `setContext()`. With await, the setContext will return an `Promise<void>` that resolves when the configurations are successfully fetched and rejects with error if unsuccessful.
- The SDK will throw Error only during initialisation. After the successful initialisation, if fetchApi fails or websocket connect fails, errors are not thrown but are to silently retried like what is happening currently.
- continue to emit `'configurationUpdate'` event upon
    - successful initialisation
    - change in feature flag or property
- Removed the deprecated params of setContext - `configurationFile` & `liveConfigUpdateEnable`. These are part of options object.
- More validations have been added for setContext().
- readme update
- SDK release version is v0.6.0