### PR TITLE
new API endpoint for GET config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-15T06:58:49Z",
+  "generated_at": "2023-09-29T08:42:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ await appConfigClient.setContext(collectionId, environmentId, {
 ```
 This usecase will throw error if given `bootstrapFile` is not found or if unable to parse the json coming from the bootstrap file.
 
-* bootstrapFile: Absolute path of the JSON file, which contains configuration details. Make sure to provide a proper JSON file. You can generate this file using `ibmcloud ac config` command of the IBM Cloud App Configuration CLI.
+* bootstrapFile: Absolute path of the JSON file, which contains configuration details. Make sure to provide a proper JSON file. You can generate this file using `ibmcloud ac export` command of the IBM Cloud App Configuration CLI.
 * liveConfigUpdateEnabled: Live configuration update from the server. Set this value to `false` if the new configuration values shouldn't be fetched from the server.
 
 ## Get single feature

--- a/lib/configurations/ConfigurationHandler.js
+++ b/lib/configurations/ConfigurationHandler.js
@@ -32,7 +32,8 @@ const { Segment } = require('./models/Segment');
 const { SegmentRules } = require('./models/SegmentRules');
 const { SecretProperty } = require("./models/SecretProperty");
 const { FileManager } = require('./internal/FileManager');
-const { getNormalizedValue, reportError } = require('./internal/Utils');
+const { reportError, getNormalizedValue, extractConfigurationsFromBootstrapJson, formatConfig,
+  extractConfigurationsFromAPIResponse, extractConfigurationsFromPersistentCache } = require('./internal/Utils');
 const { connectWebSocket } = require('./internal/Socket');
 const { events } = require('./internal/Events');
 const { Constants } = require('./internal/Constants');
@@ -62,7 +63,6 @@ const ConfigurationHandler = () => {
   let _liveUpdate = true;
   let _bootstrapFile;
   let _persistentCacheDirectory;
-  let persistentData;
   let _onSocketRetry = false;
 
   let _featureMap = {};
@@ -159,9 +159,11 @@ const ConfigurationHandler = () => {
     async function fetchFromAPI() {
       const parameters = {
         options: {
-          url: `/apprapp/feature/v1/instances/${_guid}/collections/${_collectionId}/config`,
+          url: `/apprapp/feature/v1/instances/${_guid}/config`,
           method: 'GET',
           qs: {
+            action: 'sdkConfig',
+            collection_id: _collectionId,
             environment_id: _environmentId,
           },
         },
@@ -209,7 +211,8 @@ const ConfigurationHandler = () => {
       // b) asynchronously write the response to persistent volume, if enabled
 
       logger.log(`${Constants.SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS}. Status code:${_response.status}`);
-      loadConfigurationsToCache(_response.result);
+      const configurations = extractConfigurationsFromAPIResponse(_response.result);
+      loadConfigurationsToCache(configurations);
       emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
       if (_persistentCacheDirectory) {
         try {
@@ -218,13 +221,6 @@ const ConfigurationHandler = () => {
           logger.error(`Failed to write the configurations to persistent storage. Reason: ${e}`);
         }
       }
-    }
-
-    function isJSONDataEmpty(jsonData) {
-      if (Object.keys(jsonData).length === 0) {
-        return true;
-      }
-      return false;
     }
 
     function beginWebsocketAndCheckInternet() {
@@ -257,11 +253,18 @@ const ConfigurationHandler = () => {
       _bootstrapFile = options.bootstrapFile;
       _liveUpdate = options.liveConfigUpdateEnabled;
 
+      let persistentCacheRead = false;
+      let errorReadingBootstrapConfig = false;
+
       if (_persistentCacheDirectory) {
         logger.info(`persistent cache directory path is: ${_persistentCacheDirectory}`);
         const filePath = path.join(_persistentCacheDirectory, 'appconfiguration.json');
-        persistentData = FileManager.readPersistentCacheConfigurations(filePath);
-        loadConfigurationsToCache(persistentData);
+        const persistentCache = FileManager.readPersistentCacheConfigurations(filePath);
+        if (Object.keys(persistentCache).length > 0) {
+          const configurations = extractConfigurationsFromPersistentCache(persistentCache);
+          loadConfigurationsToCache(configurations);
+          persistentCacheRead = true;
+        }
         try {
           fs.accessSync(_persistentCacheDirectory, fs.constants.W_OK);
         } catch (err) {
@@ -271,11 +274,12 @@ const ConfigurationHandler = () => {
 
       if (_bootstrapFile) {
         if (_persistentCacheDirectory) {
-          if (isJSONDataEmpty(persistentData)) {
+          if (!persistentCacheRead) {
             try {
-              const bootstrapFileData = FileManager.readBootstrapConfigurations(_bootstrapFile);
-              loadConfigurationsToCache(bootstrapFileData);
-              writeToPersistentStorage(bootstrapFileData);
+              const bootstrapConfig = FileManager.readBootstrapConfigurationsFromFile(_bootstrapFile);
+              const configurations = extractConfigurationsFromBootstrapJson(bootstrapConfig, _collectionId, _environmentId);
+              loadConfigurationsToCache(configurations);
+              writeToPersistentStorage(formatConfig(configurations, _environmentId));
               if (!_liveUpdate) emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
             } catch (e) {
               reportError(e);
@@ -284,11 +288,14 @@ const ConfigurationHandler = () => {
         } else {
           logger.info(`reading configurations from bootstrap file: ${_bootstrapFile}`);
           try {
-            const bootstrapFileData = FileManager.readBootstrapConfigurations(_bootstrapFile);
-            loadConfigurationsToCache(bootstrapFileData);
+            const bootstrapConfig = FileManager.readBootstrapConfigurationsFromFile(_bootstrapFile);
+            const configurations = extractConfigurationsFromBootstrapJson(bootstrapConfig, _collectionId, _environmentId);
+            loadConfigurationsToCache(configurations);
             if (!_liveUpdate) emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
           } catch (e) {
-            reportError(e);
+            if (!_liveUpdate) reportError(e);
+            logger.error(`${e.message}`);
+            errorReadingBootstrapConfig = true;
           }
         }
       }
@@ -296,9 +303,11 @@ const ConfigurationHandler = () => {
       if (_liveUpdate) {
         const parameters = {
           options: {
-            url: `/apprapp/feature/v1/instances/${_guid}/collections/${_collectionId}/config`,
+            url: `/apprapp/feature/v1/instances/${_guid}/config`,
             method: 'GET',
             qs: {
+              action: 'sdkConfig',
+              collection_id: _collectionId,
               environment_id: _environmentId,
             },
           },
@@ -318,14 +327,14 @@ const ConfigurationHandler = () => {
           if (statusCode >= 400 && statusCode < 499 && statusCode !== 429) {
             reportError(errMsg);
           }
-          if (_persistentCacheDirectory !== null && !isJSONDataEmpty(persistentData)) {
+          if (_persistentCacheDirectory !== null && persistentCacheRead) {
             const message = `Loaded the configurations from the persistent storage: ${path.join(_persistentCacheDirectory, 'appconfiguration.json')} into the application.`
             logger.info(`${errMsg}. ${message}`);
             emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER, message);
             beginWebsocketAndCheckInternet();
             return;
           }
-          if (_bootstrapFile !== null) {
+          if (_bootstrapFile !== null && !errorReadingBootstrapConfig) {
             const message = `Loaded the configurations from the bootstrap file: ${_bootstrapFile} into the application.`;
             logger.info(`${errMsg}. ${message}`);
             emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER, message);
@@ -336,7 +345,8 @@ const ConfigurationHandler = () => {
         }
 
         logger.log(`${Constants.SUCCESSFULLY_FETCHED_THE_CONFIGURATIONS}. Status code:${_response.status}`);
-        loadConfigurationsToCache(_response.result);
+        const configurations = extractConfigurationsFromAPIResponse(_response.result);
+        loadConfigurationsToCache(configurations);
         emitter.emit(Constants.APPCONFIGURATION_CLIENT_EMITTER);
         if (_persistentCacheDirectory) {
           // asynchronously write the response to persistent volume, if enabled

--- a/lib/configurations/internal/FileManager.js
+++ b/lib/configurations/internal/FileManager.js
@@ -78,13 +78,13 @@ function readPersistentCacheConfigurations(filePath) {
 /**
  * Read bootstrap configurations from the given file path.
  *
- * @method module:FileManager#readBootstrapConfigurations
+ * @method module:FileManager#readBootstrapConfigurationsFromFile
  * @param {string} filePath - File path from where the configurations data should be read
  * 
  * @returns JSON parsed bootstrap configurations from the given file path, if there was no error reading it.
  * @throws {Error} If filePath doesn't exists or is empty or fails to parse the json.
  */
-function readBootstrapConfigurations(filePath) {
+function readBootstrapConfigurationsFromFile(filePath) {
   let data = {};
   if (!fs.existsSync(filePath)) {
     throw new Error(`given bootstrap file path doesn't exist: ${filePath}`);
@@ -119,7 +119,7 @@ function deleteFileData(filePath) {
 }
 
 module.exports.FileManager = {
-  readBootstrapConfigurations,
+  readBootstrapConfigurationsFromFile,
   readPersistentCacheConfigurations,
   storeFiles,
   deleteFileData,

--- a/lib/configurations/internal/Utils.js
+++ b/lib/configurations/internal/Utils.js
@@ -30,6 +30,113 @@ function getNormalizedValue(str) {
   return Math.floor((computeHash(str) / MAX_HASH_VALUE) * NORMALIZER);
 }
 
+/**
+ * 1. Validate the bootstrap configurations.
+ * 2. Extract all the features, properties & segments that are under {environmentId} and assigned to {collectionId} 
+ */
+function extractConfigurationsFromBootstrapJson(bootstrapFileData, collectionId, environmentId) {
+  try {
+    if (!Array.isArray(bootstrapFileData.environments)) throw new Error(`no environments`);
+    if (!Array.isArray(bootstrapFileData.collections)) throw new Error(`no collections`);
+
+    const matchingEnv = bootstrapFileData.environments.find((env) => env.environment_id === environmentId);
+    if (matchingEnv === undefined) {
+      throw new Error(`no data matching for environment id: ${environmentId}`);
+    }
+    const matchingCollection = bootstrapFileData.collections.find((col) => col.collection_id === collectionId);
+    if (matchingCollection === undefined) {
+      throw new Error(`no data matching for collection id: ${collectionId}`);
+    }
+
+    let features = [];
+    let properties = [];
+    const segmentIds = new Set();
+    const segments = [];
+
+    if (Array.isArray(matchingEnv.features)) {
+      features = matchingEnv.features.filter((feature) => {
+        const match = feature.collections.some((col) => col.collection_id === collectionId);
+        if (match) {
+          feature.segment_rules.forEach((segmentRule) => {
+            segmentRule.rules.forEach((rule) => {
+              rule.segments.forEach((segment) => {
+                segmentIds.add(segment);
+              })
+            })
+          })
+        }
+        return match;
+      });
+    }
+    if (Array.isArray(matchingEnv.properties)) {
+      properties = matchingEnv.properties.filter((property) => {
+        const match = property.collections.some((col) => col.collection_id === collectionId);
+        if (match) {
+          property.segment_rules.forEach((segmentRule) => {
+            segmentRule.rules.forEach((rule) => {
+              rule.segments.forEach((segment) => {
+                segmentIds.add(segment);
+              })
+            })
+          })
+        }
+        return match;
+      });
+    }
+    if (segmentIds.size > 0) {
+      if (!Array.isArray(bootstrapFileData.segments)) throw new Error(`no segments`);
+      segmentIds.forEach((segmentId) => {
+        const matchingSeg = bootstrapFileData.segments.find((segment) => segment.segment_id === segmentId);
+        if (matchingSeg === undefined) {
+          throw new Error(`no data matching for segment id: ${segmentId}`);
+        }
+        segments.push(matchingSeg);
+      })
+    }
+    return {
+      features,
+      properties,
+      segments,
+    }
+  } catch (e) {
+    throw new Error(`Error occured while reading bootstrap configurations - ${e.message}`);
+  }
+}
+
+/**
+ * Extract all the features, properties & segments.
+ */
+function extractConfigurationsFromAPIResponse(res) {
+  let features = [];
+  let properties = [];
+  let segments = [];
+
+  if (res && Array.isArray(res.environments) && res.environments[0]) {
+    features = res.environments[0].features;
+    properties = res.environments[0].properties;
+  }
+  segments = res.segments;
+
+  return {
+    features,
+    properties,
+    segments,
+  }
+}
+
+function formatConfig(res, environmentId) {
+  return {
+    environments: [
+      {
+        environment_id: environmentId,
+        features: res.features,
+        properties: res.properties,
+      }
+    ],
+    segments: res.segments
+  }
+}
+
 function reportError(message) {
   logger.error(message);
   throw new Error(message);
@@ -37,5 +144,9 @@ function reportError(message) {
 
 module.exports = {
   getNormalizedValue,
+  extractConfigurationsFromBootstrapJson,
+  extractConfigurationsFromAPIResponse,
+  extractConfigurationsFromPersistentCache: extractConfigurationsFromAPIResponse,
+  formatConfig,
   reportError,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ibm-appconfiguration-node-sdk",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "IBM Cloud App Configuration Node.js SDK",
   "main": "./lib/AppConfiguration.js",
   "scripts": {

--- a/test/unit/configurations/bootstrap-configurations.json
+++ b/test/unit/configurations/bootstrap-configurations.json
@@ -1,152 +1,304 @@
 {
-  "features": [
+  "environments": [
     {
-      "name": "Prime cars",
-      "feature_id": "prime-cars",
-      "type": "BOOLEAN",
-      "enabled_value": false,
-      "disabled_value": false,
-      "segment_rules": [
-        {
-          "rules": [
-            {
-              "segments": [
-                "kp3ydh3k"
-              ]
-            }
-          ],
-          "value": true,
-          "order": 1,
-          "rollout_percentage": 100
-        }
-      ],
-      "enabled": true,
-      "rollout_percentage": 100
-    },
-    {
-      "name": "Weekend discount",
-      "feature_id": "weekend-discount",
-      "type": "NUMERIC",
-      "enabled_value": 5,
-      "disabled_value": 0,
-      "segment_rules": [
-        {
-          "rules": [
-            {
-              "segments": [
-                "kp3yb6t1"
-              ]
-            }
-          ],
-          "value": 25,
-          "order": 1,
-          "rollout_percentage": 90
-        }
-      ],
-      "enabled": true,
-      "rollout_percentage": 50
-    }
-  ],
-  "properties": [
-    {
-      "name": "Age",
-      "property_id": "age",
+      "name": "Test environment",
+      "environment_id": "test-environment",
+      "description": "My test environment",
       "tags": "",
-      "type": "NUMERIC",
-      "value": 18,
-      "segment_rules": [
+      "color_code": "#FDD13A",
+      "features": [
         {
-          "rules": [
+          "name": "Prime cars",
+          "feature_id": "prime-cars",
+          "description": "",
+          "tags": "",
+          "type": "BOOLEAN",
+          "enabled_value": false,
+          "disabled_value": false,
+          "segment_rules": [
             {
-              "segments": [
-                "kp3ydh3k"
-              ]
+              "rules": [
+                {
+                  "segments": [
+                    "kp3ydh3k"
+                  ]
+                }
+              ],
+              "value": true,
+              "order": 1,
+              "rollout_percentage": 100
             }
           ],
-          "value": 21,
-          "order": 1
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            }
+          ],
+          "enabled": true,
+          "rollout_percentage": 100,
+          "isOverridden": true
+        },
+        {
+          "name": "Weekend discount",
+          "feature_id": "weekend-discount",
+          "description": "",
+          "tags": "",
+          "type": "NUMERIC",
+          "enabled_value": 5,
+          "disabled_value": 0,
+          "segment_rules": [
+            {
+              "rules": [
+                {
+                  "segments": [
+                    "kp3yb6t1"
+                  ]
+                }
+              ],
+              "value": 25,
+              "order": 1,
+              "rollout_percentage": 90
+            }
+          ],
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            },
+            {
+              "collection_id": "my-collection",
+              "name": "My collection"
+            }
+          ],
+          "enabled": true,
+          "rollout_percentage": 50,
+          "isOverridden": true
         }
       ],
-      "created_time": "2021-05-25T11:21:00Z",
-      "updated_time": "2021-05-25T11:27:38Z"
-    },
-    {
-      "name": "Campaign name",
-      "property_id": "campaign-name",
-      "tags": "",
-      "type": "STRING",
-      "value": "New year celebrations",
-      "segment_rules": [],
-      "created_time": "2021-05-25T11:20:04Z",
-      "updated_time": "2021-05-25T11:20:04Z"
-    }
-  ],
-  "segments": [
-    {
-      "name": "Beta users",
-      "segment_id": "kp3ydh3k",
-      "rules": [
+      "properties": [
         {
-          "values": [
-            "true"
+          "name": "Age",
+          "property_id": "age",
+          "description": "",
+          "tags": "",
+          "type": "NUMERIC",
+          "value": 18,
+          "segment_rules": [
+            {
+              "rules": [
+                {
+                  "segments": [
+                    "kp3ydh3k"
+                  ]
+                }
+              ],
+              "value": 21,
+              "order": 1
+            }
           ],
-          "operator": "is",
-          "attribute_name": "paid"
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            },
+            {
+              "collection_id": "my-collection",
+              "name": "My collection"
+            }
+          ],
+          "isOverridden": true
+        },
+        {
+          "name": "Campaign name",
+          "property_id": "campaign-name",
+          "description": "",
+          "tags": "",
+          "type": "STRING",
+          "format": "TEXT",
+          "value": "New year celebrations",
+          "segment_rules": [],
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            }
+          ],
+          "isOverridden": true
         }
       ]
     },
     {
+      "name": "Staging",
+      "environment_id": "staging",
+      "description": "Testing environment. Also called as pre-prod",
+      "tags": "",
+      "color_code": "#e0929b",
+      "features": [
+        {
+          "name": "Prime cars",
+          "feature_id": "prime-cars",
+          "description": "",
+          "type": "BOOLEAN",
+          "enabled_value": false,
+          "disabled_value": false,
+          "segment_rules": [],
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            }
+          ],
+          "enabled": false,
+          "rollout_percentage": 100,
+          "isOverridden": false
+        },
+        {
+          "name": "Weekend discount",
+          "feature_id": "weekend-discount",
+          "description": "",
+          "type": "NUMERIC",
+          "enabled_value": 0,
+          "disabled_value": 0,
+          "segment_rules": [],
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            },
+            {
+              "collection_id": "my-collection",
+              "name": "My collection"
+            }
+          ],
+          "enabled": false,
+          "rollout_percentage": 100,
+          "isOverridden": false
+        }
+      ],
+      "properties": [
+        {
+          "name": "Age",
+          "property_id": "age",
+          "description": "",
+          "type": "NUMERIC",
+          "value": 0,
+          "segment_rules": [],
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            },
+            {
+              "collection_id": "my-collection",
+              "name": "My collection"
+            }
+          ],
+          "isOverridden": false
+        },
+        {
+          "name": "Campaign name",
+          "property_id": "campaign-name",
+          "description": "",
+          "type": "STRING",
+          "format": "TEXT",
+          "value": "",
+          "segment_rules": [],
+          "collections": [
+            {
+              "collection_id": "test-collection",
+              "name": "Test collection"
+            }
+          ],
+          "isOverridden": false
+        }
+      ]
+    }
+  ],
+  "collections": [
+    {
+      "name": "My collection",
+      "collection_id": "my-collection",
+      "description": "",
+      "tags": ""
+    },
+    {
+      "name": "Test collection",
+      "collection_id": "test-collection",
+      "description": "",
+      "tags": ""
+    }
+  ],
+  "segments": [
+    {
       "name": "An IBM employee",
       "segment_id": "kp3yb6t1",
+      "description": "",
+      "tags": "",
       "rules": [
         {
+          "attribute_name": "email",
+          "operator": "startsWith",
           "values": [
             "alice"
-          ],
-          "operator": "startsWith",
-          "attribute_name": "email"
+          ]
         },
         {
-          "values": [
-            "ibm.com"
-          ],
+          "attribute_name": "email",
           "operator": "endsWith",
-          "attribute_name": "email"
+          "values": [
+            "@ibm.com"
+          ]
         },
         {
+          "attribute_name": "email",
+          "operator": "contains",
           "values": [
             "@"
-          ],
-          "operator": "contains",
-          "attribute_name": "email"
+          ]
         },
         {
+          "attribute_name": "band_level",
+          "operator": "greaterThan",
           "values": [
             "6"
-          ],
-          "operator": "greaterThan",
-          "attribute_name": "band_level"
+          ]
         },
         {
-          "values": [
-            "7"
-          ],
+          "attribute_name": "band_level",
           "operator": "greaterThanEquals",
-          "attribute_name": "band_level"
-        },
-        {
           "values": [
             "7"
-          ],
-          "operator": "lesserThanEquals",
-          "attribute_name": "band_level"
+          ]
         },
         {
+          "attribute_name": "band_level",
+          "operator": "lesserThanEquals",
+          "values": [
+            "7"
+          ]
+        },
+        {
+          "attribute_name": "band_level",
+          "operator": "lesserThan",
           "values": [
             "8"
-          ],
-          "operator": "lesserThan",
-          "attribute_name": "band_level"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Beta users",
+      "segment_id": "kp3ydh3k",
+      "description": "",
+      "tags": "",
+      "rules": [
+        {
+          "attribute_name": "paid",
+          "operator": "is",
+          "values": [
+            "true"
+          ]
         }
       ]
     }

--- a/test/unit/configurations/configuration_handler.test.js
+++ b/test/unit/configurations/configuration_handler.test.js
@@ -23,7 +23,7 @@ async function setup() {
   configurationHandlerInstance = configurationHandler.getInstance();
   configurationHandlerInstance.init('region', 'guid', 'apikey', false);
   const filePath = path.join(__dirname, 'bootstrap-configurations.json');
-  configurationHandlerInstance.setContext('collectionId', 'environmentId', {
+  configurationHandlerInstance.setContext('test-collection', 'test-environment', {
     persistentCacheDirectory: __dirname,
     bootstrapFile: filePath,
     liveConfigUpdateEnabled: false,

--- a/test/unit/configurations/internal/utils.test.js
+++ b/test/unit/configurations/internal/utils.test.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-const { getNormalizedValue } = require('../../../../lib/configurations/internal/Utils');
+const { getNormalizedValue, extractConfigurationsFromBootstrapJson,
+    extractConfigurationsFromAPIResponse } = require('../../../../lib/configurations/internal/Utils');
 
 describe('utils', () => {
     test('test getNormalisedValue', () => {
@@ -24,4 +25,54 @@ describe('utils', () => {
         expect(getNormalizedValue('entityId:featureId')).toEqual(41);
 
     });
+    test('test invalid bootstrap json', () => {
+        let importJson = {
+            environments: [],
+            collections: [],
+            segments: []
+        }
+        expect(() => { extractConfigurationsFromBootstrapJson(importJson, "collection", "env") }).toThrow(Error);
+        importJson = {
+            environments: [
+                {
+                    "name": "Dev",
+                    "environment_id": "dev",
+                    "description": "Development environment",
+                    "tags": "",
+                    "color_code": "#FDD13A",
+                    "features": [],
+                    "properties": []
+                }
+            ],
+            collections: [
+                {
+                    "name": "My Collection",
+                    "collection_id": "mycollection",
+                    "description": "",
+                    "tags": ""
+                }
+            ],
+            segments: []
+        }
+        expect(() => { extractConfigurationsFromBootstrapJson(importJson, "collection", "dev") }).toThrow(Error);
+        expect(extractConfigurationsFromBootstrapJson(importJson, "mycollection", "dev").features.length).toEqual(0);
+        expect(extractConfigurationsFromBootstrapJson(importJson, "mycollection", "dev").properties.length).toEqual(0);
+        expect(extractConfigurationsFromBootstrapJson(importJson, "mycollection", "dev").segments.length).toEqual(0);
+    });
+    test('test extractConfigurationsFromAPIResponse', () => {
+        const sdkConfig = {
+            "environments": [
+                {
+                    "name": "Dev",
+                    "environment_id": "dev",
+                    "features": [],
+                    "properties": []
+                }
+            ],
+            "segments": []
+        }
+        expect(extractConfigurationsFromAPIResponse(sdkConfig).features.length).toEqual(0);
+        expect(extractConfigurationsFromAPIResponse(sdkConfig).properties.length).toEqual(0);
+        expect(extractConfigurationsFromAPIResponse(sdkConfig).segments.length).toEqual(0);
+    })
 });


### PR DESCRIPTION
1. The API endpoint for GET config is updated to new endpoint.
2. reformatted the new config API response to existing config model.
3. release version is changed to v0.7.0
4. all the changes are completely backward compatible for non-bootstrap initialisation.
5. readme has been updated asking the users to generate the bootstrap json using `ibmcloud ac export` command.
6. bootstrap based init will only accept new config format. If old config format is provided as bootstrap json then the setContext will throw error(if live update is false).
7. unit tests update