### PR TITLE
remove ip package dependency

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-05-23T05:57:58Z",
+  "generated_at": "2024-06-10T13:44:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/lib/configurations/internal/Connectivity.js
+++ b/lib/configurations/internal/Connectivity.js
@@ -18,7 +18,7 @@
  * Module to check the internet connectivity.
  * @module Connectivity
  */
-const internetAvailable = require('internet-available');
+const dnsSocket = require('dns-socket');
 
 /**
  * It returns a promise that is fulfilled if there's internet, otherwise if there's no internet
@@ -29,14 +29,30 @@ const internetAvailable = require('internet-available');
  */
 module.exports.checkInternet = function isConnected() {
   return new Promise((resolve) => {
-    internetAvailable({
+
+    const socket = dnsSocket({
       timeout: 5000,
-      retries: 2,
-      domainName: 'cloud.ibm.com',
-    }).then(() => {
-      resolve(true);
-    }).catch(() => {
-      resolve(false);
+      retries: 2
     });
+
+    socket.query({
+      questions: [{
+        type: 'A',
+        name: 'cloud.ibm.com'
+      }]
+    }, 53, '8.8.8.8');
+
+    socket.on('response', () => {
+      socket.destroy(() => {
+        resolve(true);
+      });
+    });
+
+    socket.on('timeout', () => {
+      socket.destroy(() => {
+        resolve(false);
+      });
+    });
+
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ibm-appconfiguration-node-sdk",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.0",
+        "dns-socket": "^4.2.2",
         "events": "^3.2.0",
         "ibm-cloud-sdk-core": "^4.3.1",
-        "internet-available": "^1.0.0",
         "murmurhash": "^2.0.0",
         "path": "^0.12.7",
         "websocket": "^1.0.33"
@@ -1621,6 +1621,11 @@
         "node": ">=v12.0.0"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2675,20 +2680,25 @@
       }
     },
     "node_modules/dns-packet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "dependencies": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dns-socket": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.3.tgz",
-      "integrity": "sha512-/mUy3VGqIP69dAZjh2xxHXcpK9wk2Len1Dxz8mWAdrIgFC8tnR/aQAyU4a+UTXzOcTvEvGBdp1zFiwnpWKaXng==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
+      "integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
       "dependencies": {
-        "dns-packet": "^1.1.0"
+        "dns-packet": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -3936,19 +3946,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/internet-available": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/internet-available/-/internet-available-1.0.0.tgz",
-      "integrity": "sha512-jjQa6/nRKU01TlMDL4Ksxtp409PHhnTMByz8/9leJLh1xxO2Dpi6gRNH5UrDi7nW2oaluJWN7VX2IXcxsoER6A==",
-      "dependencies": {
-        "dns-socket": "^1.6.1"
-      }
-    },
-    "node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -9012,6 +9009,11 @@
         "lodash": "^4.17.21"
       }
     },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9817,20 +9819,19 @@
       "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ=="
     },
     "dns-packet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
     "dns-socket": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.3.tgz",
-      "integrity": "sha512-/mUy3VGqIP69dAZjh2xxHXcpK9wk2Len1Dxz8mWAdrIgFC8tnR/aQAyU4a+UTXzOcTvEvGBdp1zFiwnpWKaXng==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
+      "integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
       "requires": {
-        "dns-packet": "^1.1.0"
+        "dns-packet": "^5.2.4"
       }
     },
     "doctrine": {
@@ -10754,19 +10755,6 @@
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       }
-    },
-    "internet-available": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/internet-available/-/internet-available-1.0.0.tgz",
-      "integrity": "sha512-jjQa6/nRKU01TlMDL4Ksxtp409PHhnTMByz8/9leJLh1xxO2Dpi6gRNH5UrDi7nW2oaluJWN7VX2IXcxsoER6A==",
-      "requires": {
-        "dns-socket": "^1.6.1"
-      }
-    },
-    "ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "is-array-buffer": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "IBM Cloud App Configuration Node.js SDK",
   "main": "./lib/AppConfiguration.js",
   "scripts": {
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
+    "dns-socket": "^4.2.2",
     "events": "^3.2.0",
     "ibm-cloud-sdk-core": "^4.3.1",
-    "internet-available": "^1.0.0",
     "murmurhash": "^2.0.0",
     "path": "^0.12.7",
     "websocket": "^1.0.33"


### PR DESCRIPTION
The IP package has vulnerability - https://github.com/indutny/node-ip/issues/150 and no patch is provided yet https://github.com/advisories/GHSA-2p57-rm9w-gvfp

This PR removes the dependency from the `ip` package and implements the internet check logic using `dns-socket` package. With this new code changes the "internet disconnect" usecase is retested manually and verified that it works the same way as earlier. (i.e., the SDK reestablishes a new websocket connection & force fetches the latest feature flag values once the internet connectivity is back)

Patch version of the SDK is bumped. The new release version is v0.7.6