### PR TITLE
Fixes cache getting out of sync when deleting feature/property/segment

### DIFF
--- a/lib/configurations/ConfigurationHandler.js
+++ b/lib/configurations/ConfigurationHandler.js
@@ -123,7 +123,7 @@ const ConfigurationHandler = () => {
      */
     function loadConfigurationsToCache(data) {
       if (data) {
-        if (data.features && Object.keys(data.features).length) {
+        if (data.features) {
           const { features } = data;
           allFeatureFlags = features;
           _featureMap = {};
@@ -131,14 +131,14 @@ const ConfigurationHandler = () => {
             _featureMap[feature.feature_id] = new Feature(feature);
           });
         }
-        if (data.properties && Object.keys(data.properties).length) {
+        if (data.properties) {
           const { properties } = data;
           _propertyMap = {};
           properties.forEach((property) => {
             _propertyMap[property.property_id] = new Property(property);
           });
         }
-        if (data.segments && Object.keys(data.segments).length) {
+        if (data.segments) {
           const { segments } = data;
           _segmentMap = {};
           segments.forEach((segment) => {
@@ -952,6 +952,7 @@ const ConfigurationHandler = () => {
       propertyEvaluation,
       cleanup,
       recordEvaluation,
+      loadConfigurationsToCache,
     };
   }
 

--- a/test/unit/configurations/configuration_handler.test.js
+++ b/test/unit/configurations/configuration_handler.test.js
@@ -116,4 +116,189 @@ describe('configuration handler', () => {
     const segment = configurationHandlerInstance.getSegment('kp3yb6t1');
     expect(segment.name).toBe('An IBM employee');
   });
+
+  describe('loadConfigurationsToCache', () => {
+    test('load features to cache correctly', () => {
+      const feature1 = {
+        name: 'feature-1',
+        feature_id: 'feature-1',
+        type: 'BOOLEAN',
+        disabled_value: false,
+        enabled_value: true,
+        enabled: false,
+        rollout_percentage: 100,
+        segment_rules: [],
+      };
+
+      const data = {
+        features: [feature1]
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      const feature = configurationHandlerInstance.getFeature(feature1.feature_id);
+  
+      expect(feature).toEqual(expect.objectContaining(feature1));
+    });
+
+    test('load properties to cache correctly', () => {
+      const property1 = {
+          name: 'property-1',
+          property_id: 'property-1',
+          type: 'STRING',
+          value: 'value-1',
+          segment_rules: [],
+      };
+      const data = {
+        properties: [property1]
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      const property = configurationHandlerInstance.getProperty(property1.property_id);
+  
+      expect(property).toEqual(expect.objectContaining(property1));
+    });
+
+    test('load segments to cache correctly', () => {
+      const segment1 = {
+        name: 'segment-1',
+        segment_id: 'segment-1',
+        rules: [],
+      }
+      const data = {
+        segments: [segment1]
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      const segment = configurationHandlerInstance.getSegment(segment1.segment_id);
+  
+      expect(segment).toEqual(expect.objectContaining(segment1));
+    });
+
+    test('remove deleted feature from cache', () => {
+      const feature1 = {
+        name: 'feature-1',
+        feature_id: 'feature-1',
+        type: 'BOOLEAN',
+        disabled_value: false,
+        enabled_value: true,
+        enabled: false,
+        rollout_percentage: 100,
+        segment_rules: [],
+      };
+
+      const feature2 = {
+        name: 'feature-2',
+        feature_id: 'feature-2',
+        type: 'BOOLEAN',
+        disabled_value: false,
+        enabled_value: true,
+        enabled: false,
+        rollout_percentage: 100,
+        segment_rules: [],
+      };
+
+      const data = {
+        features: [feature1, feature2]
+      };
+
+      const dataUpdated = {
+        features: [feature2]
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      configurationHandlerInstance.loadConfigurationsToCache(dataUpdated);
+      const featureObj1 = configurationHandlerInstance.getFeature(feature1.feature_id);
+      const featureObj2 = configurationHandlerInstance.getFeature(feature2.feature_id);
+  
+      expect(featureObj1).toBe(null);
+      expect(featureObj2).toEqual(expect.objectContaining(feature2));
+    });
+
+    test('remove deleted feature from cache (edge case)', () => {
+      const feature1 = {
+        name: 'feature-1',
+        feature_id: 'feature-1',
+        type: 'BOOLEAN',
+        disabled_value: false,
+        enabled_value: true,
+        enabled: false,
+        rollout_percentage: 100,
+        segment_rules: [],
+      };
+
+      const data = {
+        features: [feature1]
+      };
+
+      const dataUpdated = {
+        features: []
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      configurationHandlerInstance.loadConfigurationsToCache(dataUpdated);
+      const feature = configurationHandlerInstance.getFeature(feature1.feature_id);
+  
+      expect(feature).toBe(null);
+    });
+
+    test('remove deleted property from cache', () => {
+      const property1 = {
+        name: 'property-1',
+        property_id: 'property-1',
+        type: 'STRING',
+        value: 'hello world',
+        segment_rules: [],
+      };
+
+      const property2 = {
+        name: 'property-2',
+        property_id: 'property-2',
+        type: 'NUMERIC',
+        value: 42,
+        segment_rules: [],
+      };
+
+      const data = {
+        properties: [property1, property2]
+      };
+
+      const dataUpdated = {
+        properties: [property2]
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      configurationHandlerInstance.loadConfigurationsToCache(dataUpdated);
+
+      const propertyObj1 = configurationHandlerInstance.getProperty(property1.property_id);
+      const propertyObj2 = configurationHandlerInstance.getProperty(property2.property_id);
+
+      expect(propertyObj1).toBe(null);
+      expect(propertyObj2).toEqual(expect.objectContaining(property2));
+    });
+
+    test('remove deleted property from cache (edge case)', () => {
+      const property1 = {
+        name: 'property-1',
+        property_id: 'property-1',
+        type: 'STRING',
+        value: 'hello world',
+        segment_rules: [],
+      };
+
+      const data = {
+        properties: [property1]
+      };
+
+      const dataUpdated = {
+        properties: []
+      };
+
+      configurationHandlerInstance.loadConfigurationsToCache(data);
+      configurationHandlerInstance.loadConfigurationsToCache(dataUpdated);
+      const property = configurationHandlerInstance.getProperty(property1.property_id);
+
+      expect(property).toBe(null);
+    })
+  });
+
 });


### PR DESCRIPTION
# Summary

This PR fixes an edge case where deleting features, properties, or segments leads to stale cache data in the app.

# Problem

Whenever a feature is created, updated, or deleted, clients are notified via socket and trigger a refetch from IBM Cloud.
However, the following scenario causes issues:

- Only one feature flag exists in IBM Cloud.
- The app loads this feature flag.
- The feature flag is deleted from IBM Cloud.
- The app receives the deletion notification and attempts to refetch.

Since `features.length` is 0, the cache update is skipped.

The cache remains stale and queries for the feature flag return the old value even though it was deleted.

This issue affects both features and properties. It only works correctly if there are multiple items in IBM Cloud (e.g., deleting one feature still leaves others behind).

# Fix

The cache update logic is adjusted to properly handle empty results, ensuring that deletions are correctly reflected and stale values are removed.