### PR TITLE
stale connection detection, exponential retry strategy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,21 @@
-# This is an example configuration to enable whitewater-detect-secrets in the pre-commit hook.
+# This is an example configuration to enable detect-secrets in the pre-commit hook.
 # Add this file to the root folder of your repository.
 #
 # Read pre-commit hook framework https://pre-commit.com/ for more details about the structure of config yaml file and how git pre-commit would invoke each hook.
 #
-# This line indicates we will use the hook from Whitewater/whitewater-detect-secrets to run scan during commiting phase.
+# This line indicates we will use the hook from ibm/detect-secrets to run scan during committing phase.
 repos:
-  - repo: git@github.ibm.com:Whitewater/whitewater-detect-secrets
-    # If you desire to use a specific version of whitewater-detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
-    rev: 0.13.1+ibm.62.dss
-    hooks:
+- repo: https://github.com/ibm/detect-secrets
+  # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
+  # You are encouraged to use static refs such as tags, instead of branch name
+  #
+  # Running "pre-commit autoupdate" would automatically updates rev to latest tag
+  rev: 0.13.1+ibm.64.dss
+  hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.
         # You may also run `pre-commit run detect-secrets` to preview the scan result.
-        #
-        # The `--no-keyword-scan` field can be removed if you are using 0.10.3-ibm.1. It was added prior to 0.10.3-ibm.1 to reduce false positives generated from old keyword scanner.
-        # After 0.10.3-ibm.1, keyword scanner is disabled by default.
-        args:
-          [--baseline, .secrets.baseline, --use-all-plugins, --no-keyword-scan]
+        # when "--baseline" without "--use-all-plugins", pre-commit scan with just plugins in baseline file
+        # when "--baseline" with "--use-all-plugins", pre-commit scan with all available plugins
+        # add "--fail-on-unaudited" to fail pre-commit for unaudited potential secrets
+        args: [--baseline, .secrets.baseline, --use-all-plugins]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,13 +3,16 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-24T13:13:50Z",
+  "generated_at": "2026-01-30T06:18:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
     },
     {
       "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "base64_limit": 4.5,
@@ -29,6 +32,9 @@
       "name": "GheDetector"
     },
     {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "hex_limit": 3,
       "name": "HexHighEntropyString"
     },
@@ -42,7 +48,14 @@
       "name": "JwtTokenDetector"
     },
     {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
       "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
     },
     {
       "name": "PrivateKeyDetector"
@@ -54,14 +67,36 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
-  "version": "0.13.1+ibm.62.dss",
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "32e8612d8ca77c7ea8374aa7918db8e5df9252ed",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3977ca220330e7f41cbedf72d147a7d445014ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 307,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install ibm-appconfiguration-node-sdk@latest
 
 ## Import the SDK
 
-To import the module
+To import the module,
 
 ```JS
 const { AppConfiguration } = require('ibm-appconfiguration-node-sdk');

--- a/lib/configurations/ConfigurationHandler.js
+++ b/lib/configurations/ConfigurationHandler.js
@@ -922,7 +922,9 @@ const ConfigurationHandler = () => {
     });
 
     emitter.on(Constants.SOCKET_CALLBACK, () => {
-      socketActions();
+      // Not calling the socketActions() immediately, instead added a random delay b/w 0-5s
+      // to prevent thundering herd of "GET /config" requests when large number of clients are present
+      setTimeout(() => socketActions(), Math.random() * 5000);
     });
 
     emitter.on(Constants.SOCKET_MESSAGE_ERROR, (messageType) => {

--- a/lib/configurations/internal/Socket.js
+++ b/lib/configurations/internal/Socket.js
@@ -32,34 +32,131 @@ const socketClient = new WebSocketClient({ closeTimeout: 120000 });
 const logger = Logger.getInstance();
 const urlBuilder = UrlBuilder.getInstance();
 const emitter = events.getInstance();
+
 let socketConnectComplete = true;
 let connectionObj;
 let _isActive = false;
+
+// Retry configuration
+const RETRY_CONFIG = {
+  initialDelay: 15 * 1000,      // Start with 15 seconds
+  maxDelay: 1 * 60 * 60 * 1000, // Cap at 1 hour
+  multiplier: 2,                // Double the delay each time
+  jitterFactor: 0.3             // Add up to 30% random jitter
+};
+
+// Watchdog configuration
+const WATCHDOG_CONFIG = {
+  checkInterval: 60 * 1000,     // Check every 60 seconds (2x heartbeat interval)
+  heartbeatTimeout: 120 * 1000  // Expect heartbeat within 120 seconds (4x heartbeat interval)
+};
+
+// Retry state
+const retryState = {
+  attempt: 0,
+  currentDelay: RETRY_CONFIG.initialDelay,
+  retryTimeoutId: null
+};
+
+// Watchdog state
+const watchdogState = {
+  intervalId: null,         // the setInterval id
+  lastHeartbeatTime: null,  //
+  isEnabled: false          // tells if watchdog is active (i.e., setInterval is running or not)
+};
+
+// Attempt: 0,  1,   2,  3,  4,  5,  6,   7,   8,   9,   10   ...
+// Output: 15s, 30s, 1m, 2m, 4m, 8m, 16m, 32m, 60m, 60m, 60m  ...
+function calculateRetryDelay() {
+  const baseDelay = Math.min(RETRY_CONFIG.initialDelay * (RETRY_CONFIG.multiplier ** retryState.attempt), RETRY_CONFIG.maxDelay);
+  const jitter = baseDelay * RETRY_CONFIG.jitterFactor * (Math.random() * 2 - 1);
+  const delayWithJitter = Math.max(0, baseDelay + jitter);
+  retryState.currentDelay = delayWithJitter;
+  return delayWithJitter;
+}
+
+// Reset the websocket retry after successful connection
+function resetRetryState() {
+  if (retryState.retryTimeoutId) {
+    clearTimeout(retryState.retryTimeoutId);
+    retryState.retryTimeoutId = null;
+  }
+  retryState.attempt = 0;
+  retryState.currentDelay = RETRY_CONFIG.initialDelay;
+}
+
+// Schedule a retry attempt with exponential backoff
+async function scheduleRetry(eventToEmit, eventData, logMsg) {
+  // Prevent multiple concurrent reconnection attempts if already triggered by any of 'error', 'close', 'connectFailed', 'httpResponse', 'watchdogTimer'.
+  if (retryState.retryTimeoutId !== null) {
+    logger.log(`${logMsg} Retry already scheduled, skipping duplicate retry attempt`);
+    return;
+  }
+  const delay = calculateRetryDelay();
+  const seconds = (delay / 1000).toFixed(2);
+  logger.warning(`${logMsg} Retrying websocket connection in ${seconds} seconds (attempt ${retryState.attempt + 1})...`);
+
+  retryState.retryTimeoutId = setTimeout(() => {
+    retryState.attempt++;
+    retryState.retryTimeoutId = null;
+    emitter.emit(eventToEmit, eventData);
+  }, delay);
+}
+
+// Watchdog timer to monitor heartbeat messages
+// If 'close' or 'error' handlers fails to detect the disconnection, this watchdog initiates a reconnect - if heartbeats received from the server are stopped.
+function startWatchdog() {
+  stopWatchdog(); // Stop existing watchdog if any
+  watchdogState.lastHeartbeatTime = Date.now(); // Initialize last heartbeat time to current time
+  watchdogState.isEnabled = true;
+  logger.log(`Watchdog timer started - monitoring heartbeat every ${WATCHDOG_CONFIG.checkInterval / 1000}s`);
+
+  watchdogState.intervalId = setInterval(() => {
+    const now = Date.now();
+    const timeSinceLastHeartbeat = now - watchdogState.lastHeartbeatTime;
+    if (timeSinceLastHeartbeat > WATCHDOG_CONFIG.heartbeatTimeout) {
+      const logMsg = `Watchdog detected stale connection - no heartbeat received for ${(timeSinceLastHeartbeat / 1000).toFixed(1)}s (threshold: ${WATCHDOG_CONFIG.heartbeatTimeout / 1000}s)`;
+      stopWatchdog();
+      _isActive = false;
+      scheduleRetry(Constants.SOCKET_CONNECTION_CLOSE, { reason: 'watchdog_timeout' }, logMsg);
+    }
+  }, WATCHDOG_CONFIG.checkInterval);
+}
+
+function stopWatchdog() {
+  if (watchdogState.intervalId) {
+    clearInterval(watchdogState.intervalId);
+    watchdogState.intervalId = null;
+  }
+  watchdogState.isEnabled = false;
+  watchdogState.lastHeartbeatTime = null;
+}
+
+function updateHeartbeat() {
+  watchdogState.lastHeartbeatTime = Date.now();
+}
 
 /**
  * Listeners for websocket connection.
  */
 socketClient.on('httpResponse', async (response) => {
   socketConnectComplete = true;
+  _isActive = false;
   const { statusCode } = response;
-  const errMsg =
-    `WebSocket connect request to the App Configuration server failed. Status code: ${statusCode}. Message: ${response.statusMessage}`
+  const errMsg = `WebSocket connect request to the App Configuration server failed. Status code: ${statusCode}. Message: ${response.statusMessage}`
   if (statusCode >= 400 && statusCode < 499 && statusCode !== 429) {
     // 'Do Nothing! Since websocket connect failed due to client-side error.
     logger.error(errMsg);
     return;
   }
-  logger.warning(`${errMsg} Retrying websocket connect in 15 seconds...`);
-  await new Promise(resolve => setTimeout(resolve, 15000));
-  emitter.emit(Constants.SOCKET_CONNECTION_ERROR, response);
+  await scheduleRetry(Constants.SOCKET_CONNECTION_ERROR, response, errMsg);
 })
 
 socketClient.on('connectFailed', async (error) => {
   socketConnectComplete = true;
   _isActive = false;
-  logger.warning(`connectFailed: ${error.message} Retrying websocket connect in 15 seconds...`);
-  await new Promise(resolve => setTimeout(resolve, 15000));
-  emitter.emit(Constants.SOCKET_CONNECTION_ERROR, error);
+  const logMsg = `connectFailed: ${error?.message ?? String(error)}`;
+  await scheduleRetry(Constants.SOCKET_CONNECTION_ERROR, error, logMsg);
 });
 
 socketClient.on('connect', (connection) => {
@@ -67,23 +164,27 @@ socketClient.on('connect', (connection) => {
   _isActive = true;
   connectionObj = connection;
 
+  // Connection successful: Reset the retry(delay, attempt) and start watchdog timer to monitor heartbeats.
+  resetRetryState();
+  startWatchdog();
   emitter.emit(Constants.SOCKET_CONNECTION_SUCCESS);
 
   connection.on('error', async (error) => {
     _isActive = false;
-    logger.warning(`websocket: received error event. ${error.message} Retrying websocket connect in 15 seconds...`)
-    await new Promise(resolve => setTimeout(resolve, 15000));
-    emitter.emit(Constants.SOCKET_LOST_ERROR, error);
+    stopWatchdog();
+    const logMsg = `websocket: received error event. ${error?.message ?? String(error)}`;
+    await scheduleRetry(Constants.SOCKET_LOST_ERROR, error, logMsg);
   });
 
   connection.on('close', async (result, description) => {
     _isActive = false;
+    stopWatchdog();
     if (result === Constants.CUSTOM_SOCKET_CLOSE_REASON_CODE) {
+      resetRetryState();
       // logger.log('Do Nothing');
     } else {
-      logger.warning(`websocket: received close event. ${result} ${description} Retrying websocket connect in 15 seconds...`)
-      await new Promise(resolve => setTimeout(resolve, 15000));
-      emitter.emit(Constants.SOCKET_CONNECTION_CLOSE);
+      const logMsg = `websocket: received close event. ${result} ${description}`;
+      await scheduleRetry(Constants.SOCKET_CONNECTION_CLOSE, null, logMsg);
     }
   });
 
@@ -91,20 +192,19 @@ socketClient.on('connect', (connection) => {
     _isActive = true;
     if (message.type === 'utf8') {
       let dataJson = {};
-
       if (message.utf8Data === 'test message') {
+        updateHeartbeat();
         emitter.emit(Constants.SOCKET_MESSAGE_RECEIVED, 'Heartbeat message');
         return;
       }
 
       const msgArray = message.utf8Data.split(';');
-
       msgArray.forEach((msg) => {
         const [key, value,] = msg.replace(/\s/g, '').split(':');
         dataJson[key] = value;
       });
-      dataJson = JSON.parse(JSON.stringify(dataJson));
 
+      dataJson = JSON.parse(JSON.stringify(dataJson));
       emitter.emit(Constants.SOCKET_MESSAGE_RECEIVED, `${JSON.stringify(dataJson)}`);
       emitter.emit(Constants.SOCKET_CALLBACK);
     } else {
@@ -115,6 +215,7 @@ socketClient.on('connect', (connection) => {
 
 function closeWebSocket() {
   if (connectionObj && connectionObj.connected) {
+    stopWatchdog();
     connectionObj.close(Constants.CUSTOM_SOCKET_CLOSE_REASON_CODE);
   }
 }
@@ -142,12 +243,39 @@ async function connectWebSocket() {
  * isConnected function return the status of websocket connection
  * @returns {boolean} status of the websocket connection
  */
-function isConnected(){
+function isConnected() {
   return _isActive;
+}
+
+// Note: currently this function is not used anywhere. It is useful for debugging/monitoring
+function getRetryState() {
+  return {
+    attempt: retryState.attempt,
+    currentDelay: retryState.currentDelay,
+    hasScheduledRetry: retryState.retryTimeoutId !== null
+  };
+}
+
+// Note: currently this function is not used anywhere. It is useful for debugging/monitoring
+function getWatchdogState() {
+  const now = Date.now();
+  const timeSinceLastHeartbeat = watchdogState.lastHeartbeatTime ? now - watchdogState.lastHeartbeatTime : null;
+
+  return {
+    isEnabled: watchdogState.isEnabled,
+    lastHeartbeatTime: watchdogState.lastHeartbeatTime,
+    timeSinceLastHeartbeat: timeSinceLastHeartbeat,
+    heartbeatTimeoutThreshold: WATCHDOG_CONFIG.heartbeatTimeout,
+    checkInterval: WATCHDOG_CONFIG.checkInterval
+  };
 }
 
 module.exports = {
   connectWebSocket,
   isConnected,
-  socketClient, // exported only for testing purpose
+
+  // exported only for testing purposes
+  socketClient,
+  getRetryState,
+  getWatchdogState
 };

--- a/lib/configurations/internal/Utils.js
+++ b/lib/configurations/internal/Utils.js
@@ -203,10 +203,34 @@ function sliceArray(array, size) {
   return result;
 }
 
+// exponential delay calculation for retries of '/usage' & '/analytics'
+// 2.x minutes base delay with jitter (0–0.9 minutes)
+function computeBaseDelayMs() {
+  const baseMs = 2 * 60 * 1000; // 2 minutes
+  const jitterMs = Math.floor(0.9 * 60 * 1000 * Math.random()); // up to 54,000ms
+  return baseMs + jitterMs; // 2.0–2.9 minutes
+}
+
+// 1 hour cap + jitter in SECONDS (0–59s)
+function computeCapDelayMs() {
+  const baseMs = 60 * 60 * 1000; // 1 hour
+  const jitterSeconds = Math.floor(Math.random() * 60); // 0–59 seconds
+  return baseMs + jitterSeconds * 1000; // 60:00–60:59 minutes
+}
+
+// Compute next delay with exponential backoff, capped
+function computeNextDelayMs(attempt, capMs) {
+  const expMs = computeBaseDelayMs() * (2 ** attempt);
+  return Math.min(expMs, capMs);
+}
+
 module.exports = {
   getNormalizedValue,
   extractConfigurations,
   formatConfig,
   reportError,
   sliceArray,
+  computeBaseDelayMs,
+  computeCapDelayMs,
+  computeNextDelayMs
 };

--- a/lib/core/EvaluationEvents.js
+++ b/lib/core/EvaluationEvents.js
@@ -18,7 +18,7 @@ const { Logger } = require('./Logger');
 const { UrlBuilder } = require('./UrlBuilder');
 const { getBaseServiceClient, getHeaders } = require('./ApiManager');
 const { Constants } = require('../configurations/internal/Constants');
-const { sliceArray } = require('../configurations/internal/Utils');
+const { sliceArray, computeCapDelayMs, computeNextDelayMs } = require('../configurations/internal/Utils');
 
 const EvaluationEvents = () => {
   let instance = null;
@@ -58,18 +58,42 @@ const EvaluationEvents = () => {
         },
       };
 
-      let _response;
-      try {
-        _response = await getBaseServiceClient().createRequest(parameters);
-        if (_response && _response.status === Constants.STATUS_CODE_ACCEPTED) {
-          logger.log(Constants.SUCCESSFULLY_POSTED_EXPERIMENT_EVALUATION_EVENTS);
-        }
-      } catch (_exception) {
-        logger.error(`${Constants.ERROR_POSTING_EXPERIMENT_EVALUATION_EVENTS}. ${_exception}`);
-        if ((_exception.status >= 500 && _exception.status <= 599) || (_exception.status === 429) || (_exception.status === undefined)) {
-          setTimeout(() => { sendToServer(guid, data); }, sendInterval);
+      // Per-payload retry state (isolated to this request)
+      const capMs = computeCapDelayMs();
+      let attempt = 0;
+
+      const attemptSend = async () => {
+        let _response;
+        try {
+          _response = await getBaseServiceClient().createRequest(parameters);
+          if (_response && _response.status === Constants.STATUS_CODE_ACCEPTED) {
+            logger.log(Constants.SUCCESSFULLY_POSTED_EXPERIMENT_EVALUATION_EVENTS);
+          }
+        } catch (_exception) {
+          const status = _exception?.status;
+          const retryable = (status >= 500 && status <= 599) || status === 429 || status === undefined;
+          logger.error(`${Constants.ERROR_POSTING_EXPERIMENT_EVALUATION_EVENTS}. ${_exception?.message || _exception}`);
+
+          if (!retryable) {
+            // 4xx (except 429) — do not retry
+            return;
+          }
+
+          // Exponential backoff with jitter until capped at ~1.x hours, then constant
+          const delayMs = computeNextDelayMs(attempt, capMs);
+          const delayMin = (delayMs / 60000).toFixed(2);
+          logger.warning(`Retrying analytics POST in ${delayMin} minutes (attempt #${attempt + 1}, cap ${(capMs / 60000).toFixed(2)} minutes).`);
+          attempt += 1;
+
+          setTimeout(() => {
+            attemptSend().catch((e) => {
+              logger.error(`Analytics retry attempt failed: ${e?.message || e}`);
+            });
+          }, delayMs);
         }
       }
+
+      await attemptSend();
     }
 
     function sendEvents() {

--- a/lib/core/Metering.js
+++ b/lib/core/Metering.js
@@ -18,6 +18,7 @@ const { Logger } = require('./Logger');
 const { UrlBuilder } = require('./UrlBuilder');
 const { getBaseServiceClient, getHeaders } = require('./ApiManager');
 const { Constants } = require('../configurations/internal/Constants');
+const { computeCapDelayMs, computeNextDelayMs } = require('../configurations/internal/Utils');
 
 /**
  * This module provides methods that perform metering and usage related operations.
@@ -159,19 +160,42 @@ const Metering = () => {
         },
       };
 
-      let _response;
+      // Per-call retry state (isolated to this payload)
+      const capMs = computeCapDelayMs();
+      let attempt = 0;
 
-      try {
-        _response = await getBaseServiceClient().createRequest(parameters);
-        if (_response && _response.status === Constants.STATUS_CODE_ACCEPTED) {
-          logger.log(Constants.SUCCESSFULLY_POSTED_METERING_DATA);
+      const attemptSend = async () => {
+        let _response;
+        try {
+          _response = await getBaseServiceClient().createRequest(parameters);
+          if (_response && _response.status === Constants.STATUS_CODE_ACCEPTED) {
+            logger.log(Constants.SUCCESSFULLY_POSTED_METERING_DATA);
+          }
+        } catch (_exception) {
+          const status = _exception?.status;
+          const retryable = (status >= 500 && status <= 599) || status === 429 || status === undefined;
+          logger.error(`${Constants.ERROR_POSTING_METERING_DATA}. ${_exception?.message || _exception}`);
+
+          if (!retryable) {
+            // 4xx (except 429) — do not retry
+            return;
+          }
+
+          // Exponential backoff with jitter until capped at ~1.x hours, then constant
+          const delayMs = computeNextDelayMs(attempt, capMs);
+          const delayMin = (delayMs / 60000).toFixed(2);
+          logger.warning(`Retrying metering POST in ${delayMin} minutes (attempt #${attempt + 1}, cap ${(capMs / 60000).toFixed(2)} minutes).`);
+          attempt += 1;
+
+          setTimeout(() => {
+            attemptSend().catch((e) => {
+              logger.error(`Metering retry attempt failed: ${e?.message || e}`);
+            });
+          }, delayMs);
         }
-      } catch (_exception) {
-        logger.error(`${Constants.ERROR_POSTING_METERING_DATA}. ${_exception}`);
-        if ((_exception.status >= 500 && _exception.status <= 599) || (_exception.status === 429) || (_exception.status === undefined)) {
-          setTimeout(() => { sendToServer(guid, data); }, meteringInterval);
-        }
-      }
+      };
+
+      await attemptSend();
     }
 
     function sendSplitMetering(guid, data, count) {

--- a/lib/core/MetricEvents.js
+++ b/lib/core/MetricEvents.js
@@ -18,7 +18,7 @@ const { Logger } = require('./Logger');
 const { UrlBuilder } = require('./UrlBuilder');
 const { getBaseServiceClient, getHeaders } = require('./ApiManager');
 const { Constants } = require('../configurations/internal/Constants');
-const { sliceArray } = require('../configurations/internal/Utils');
+const { sliceArray, computeCapDelayMs, computeNextDelayMs } = require('../configurations/internal/Utils');
 
 const MetricEvents = () => {
   let instance = null;
@@ -58,18 +58,42 @@ const MetricEvents = () => {
         },
       };
 
-      let _response;
-      try {
-        _response = await getBaseServiceClient().createRequest(parameters);
-        if (_response && _response.status === Constants.STATUS_CODE_ACCEPTED) {
-          logger.log(Constants.SUCCESSFULLY_POSTED_EXPERIMENT_METRIC_EVENTS);
+      // Per-payload retry state (isolated to this request)
+      const capMs = computeCapDelayMs();
+      let attempt = 0;
+
+      const attemptSend = async () => {
+        let _response;
+        try {
+          _response = await getBaseServiceClient().createRequest(parameters);
+          if (_response && _response.status === Constants.STATUS_CODE_ACCEPTED) {
+            logger.log(Constants.SUCCESSFULLY_POSTED_EXPERIMENT_METRIC_EVENTS);
+          }
+        } catch (_exception) {
+          const status = _exception?.status;
+          const retryable = (status >= 500 && status <= 599) || status === 429 || status === undefined;
+          logger.error(`${Constants.ERROR_POSTING_EXPERIMENT_METRIC_EVENTS}. ${_exception?.message || _exception}`);
+
+          if (!retryable) {
+            // 4xx (except 429) — do not retry
+            return;
+          }
+
+          // Exponential backoff with jitter until capped at ~1.x hours, then constant
+          const delayMs = computeNextDelayMs(attempt, capMs);
+          const delayMin = (delayMs / 60000).toFixed(2);
+          logger.warning(`Retrying analytics POST in ${delayMin} minutes (attempt #${attempt + 1}, cap ${(capMs / 60000).toFixed(2)} minutes).`);
+          attempt += 1;
+
+          setTimeout(() => {
+            attemptSend().catch((e) => {
+              logger.error(`Analytics retry attempt failed: ${e?.message || e}`);
+            });
+          }, delayMs);
         }
-      } catch (_exception) {
-        logger.error(`${Constants.ERROR_POSTING_EXPERIMENT_METRIC_EVENTS}. ${_exception}`);
-        if ((_exception.status >= 500 && _exception.status <= 599) || (_exception.status === 429) || (_exception.status === undefined)) {
-          setTimeout(() => { sendToServer(guid, data); }, sendInterval);
-        }
-      }
+      };
+
+      await attemptSend();
     }
 
     function sendEvents() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.8.0-beta.7",
+  "version": "0.8.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ibm-appconfiguration-node-sdk",
-      "version": "0.8.0-beta.7",
+      "version": "0.8.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.0",
         "dns-socket": "^4.2.2",
         "events": "^3.2.0",
-        "ibm-cloud-sdk-core": "^5.4.3",
+        "ibm-cloud-sdk-core": "^5.4.5",
         "murmurhash": "^2.0.0",
         "path": "^0.12.7",
         "websocket": "^1.0.33"
@@ -661,10 +661,11 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2143,7 +2144,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2593,6 +2595,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -3680,9 +3683,9 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.3.tgz",
-      "integrity": "sha512-D0lvClcoCp/HXyaFlCbOT4aTYgGyeIb4ncxZpxRuiuw7Eo79C6c49W53+8WJRD9nxzT5vrIdaky3NBcTdBtaEg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.5.tgz",
+      "integrity": "sha512-7ClYtr/Xob83hypKUa1D9N8/ViH71giKQ0kqjHcoyKum6yvwsWAeFA6zf6WTWb+DdZ1XSBrMPhgCCoy0bqReLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/debug": "^4.1.12",
@@ -3696,13 +3699,13 @@
         "file-type": "16.5.4",
         "form-data": "^4.0.4",
         "isstream": "0.1.2",
-        "jsonwebtoken": "^9.0.2",
+        "jsonwebtoken": "^9.0.3",
         "mime-types": "2.1.35",
         "retry-axios": "^2.6.0",
         "tough-cookie": "^4.1.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/camelcase": {
@@ -5375,10 +5378,11 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5482,11 +5486,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -5502,24 +5507,11 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5527,27 +5519,24 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -5631,40 +5620,47 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5675,7 +5671,8 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7961,9 +7958,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "3.14.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -10296,9 +10293,9 @@
       "dev": true
     },
     "ibm-cloud-sdk-core": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.3.tgz",
-      "integrity": "sha512-D0lvClcoCp/HXyaFlCbOT4aTYgGyeIb4ncxZpxRuiuw7Eo79C6c49W53+8WJRD9nxzT5vrIdaky3NBcTdBtaEg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.5.tgz",
+      "integrity": "sha512-7ClYtr/Xob83hypKUa1D9N8/ViH71giKQ0kqjHcoyKum6yvwsWAeFA6zf6WTWb+DdZ1XSBrMPhgCCoy0bqReLg==",
       "requires": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
@@ -10311,7 +10308,7 @@
         "file-type": "16.5.4",
         "form-data": "^4.0.4",
         "isstream": "0.1.2",
-        "jsonwebtoken": "^9.0.2",
+        "jsonwebtoken": "^9.0.3",
         "mime-types": "2.1.35",
         "retry-axios": "^2.6.0",
         "tough-cookie": "^4.1.3"
@@ -11622,9 +11619,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -11707,11 +11704,11 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "requires": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -11723,45 +11720,29 @@
         "semver": "^7.5.4"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "version": "7.7.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+          "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
         }
       }
     },
     "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "requires": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "requires": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -11830,9 +11811,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true
     },
     "lodash.includes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-appconfiguration-node-sdk",
-  "version": "0.8.0-beta.7",
+  "version": "0.8.0-beta.8",
   "description": "IBM Cloud App Configuration Node.js SDK",
   "main": "./lib/AppConfiguration.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "chalk": "^4.1.0",
     "dns-socket": "^4.2.2",
     "events": "^3.2.0",
-    "ibm-cloud-sdk-core": "^5.4.3",
+    "ibm-cloud-sdk-core": "^5.4.5",
     "murmurhash": "^2.0.0",
     "path": "^0.12.7",
     "websocket": "^1.0.33"


### PR DESCRIPTION
- added a watchdog timer to detect stale websocket connections (and kickoff reconnect once detected) [more details](https://github.com/IBM/appconfiguration-node-sdk/pull/58#issuecomment-3822117514)
- prevent thundering herd of /config calls when flag update event occurs [more details](https://github.com/IBM/appconfiguration-node-sdk/pull/58#issuecomment-3822122821)
- exponential retry the failed metering calls (/usage, /analytics) [more details](https://github.com/IBM/appconfiguration-node-sdk/pull/58#issuecomment-3822125975)
- vulnerability fixes